### PR TITLE
Properly quote the root prefix ('.')

### DIFF
--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -40,6 +40,8 @@ class PublishAPISection(BaseAPIClient):
 
     @staticmethod
     def escape_prefix(prefix: str) -> str:
+        if prefix == ".":
+            return ":."
         if "/" in prefix:
             # prefix has not yet been quoted as described at
             # https://www.aptly.info/doc/api/publish/

--- a/aptly_api/tests/publish.py
+++ b/aptly_api/tests/publish.py
@@ -281,3 +281,7 @@ class PublishAPISectionTests(TestCase):
             self.papi.escape_prefix("test/a"),
             "test_a"
         )
+        self.assertEqual(
+            self.papi.escape_prefix("."),
+            ":."
+        )


### PR DESCRIPTION
Hi,

We stumbled on this bug so here a PR fiing it :).
If it's good for you, could you make a release after the merge?