### PR TITLE
Update to mypy 0.600 generates errors

### DIFF
--- a/aptly_api/parts/packages.py
+++ b/aptly_api/parts/packages.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import NamedTuple, Dict, Union
+from typing import NamedTuple, Dict, Union, Optional
 from urllib.parse import quote
 
 from aptly_api.base import BaseAPIClient
@@ -12,9 +12,9 @@ from aptly_api.base import BaseAPIClient
 
 Package = NamedTuple('Package', [
     ('key', str),
-    ('short_key', str),
-    ('files_hash', str),
-    ('fields', Dict[str, str]),
+    ('short_key', Optional[str]),
+    ('files_hash', Optional[str]),
+    ('fields', Optional[Dict[str, str]]),
 ])
 
 

--- a/aptly_api/parts/repos.py
+++ b/aptly_api/parts/repos.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from typing import NamedTuple, Sequence, Dict, Union, cast
+from typing import NamedTuple, Sequence, Dict, Union, cast, Optional
 from urllib.parse import quote
 
 from aptly_api.base import BaseAPIClient, AptlyAPIException
@@ -11,9 +11,9 @@ from aptly_api.parts.packages import PackageAPISection, Package
 
 Repo = NamedTuple('Repo', [
     ('name', str),
-    ('comment', str),
-    ('default_distribution', str),
-    ('default_component', str)
+    ('comment', Optional[str]),
+    ('default_distribution', Optional[str]),
+    ('default_component', Optional[str])
 ])
 
 FileReport = NamedTuple('FileReport', [

--- a/aptly_api/parts/snapshots.py
+++ b/aptly_api/parts/snapshots.py
@@ -13,7 +13,11 @@ import pytz
 from aptly_api.base import BaseAPIClient, AptlyAPIException
 from aptly_api.parts.packages import Package, PackageAPISection
 
-Snapshot = NamedTuple('Snapshot', [('name', str), ('description', str), ('created_at', datetime)])
+Snapshot = NamedTuple('Snapshot', [
+    ('name', str),
+    ('description', Optional[str]),
+    ('created_at', Optional[datetime])
+])
 
 
 class SnapshotAPISection(BaseAPIClient):

--- a/aptly_api/parts/snapshots.py
+++ b/aptly_api/parts/snapshots.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from datetime import datetime
-from typing import NamedTuple, Sequence, Optional, Dict, Union
+from typing import NamedTuple, Sequence, Optional, Dict, Union, cast
 from urllib.parse import quote
 
 import iso8601
@@ -24,7 +24,8 @@ class SnapshotAPISection(BaseAPIClient):
     @staticmethod
     def snapshot_from_response(api_response: Dict[str, Union[str, None]]) -> Snapshot:
         return Snapshot(
-            name=api_response["Name"],
+            # use a cast() here as `name` can never be None, but the `api_response` declaration can't handle that
+            name=cast(str, api_response["Name"]),
             description=api_response["Description"] if "Description" in api_response else None,
             created_at=iso8601.parse_date(
                 api_response["CreatedAt"], default_timezone=pytz.UTC

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,4 +5,4 @@ flake8==3.5.0
 pep257==0.7.0
 doc8==0.8.0
 Pygments==2.2.0
-mypy==0.590
+mypy==0.600


### PR DESCRIPTION
Some `NamedTuple`s in the API parts declare fields not as `Optional[...]` which are treated as optional.