### PR TITLE
Make sign_gpgkey argument optional

### DIFF
--- a/aptly_api/__init__.py
+++ b/aptly_api/__init__.py
@@ -12,7 +12,7 @@ from aptly_api.parts.publish import PublishEndpoint
 from aptly_api.parts.repos import Repo, FileReport
 from aptly_api.parts.snapshots import Snapshot
 
-version = "0.1.6"
+version = "0.1.7"
 
 
 __all__ = ['Client', 'AptlyAPIException', 'version', 'Package', 'PublishEndpoint', 'Repo', 'FileReport',

--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -75,8 +75,6 @@ class PublishAPISection(BaseAPIClient):
                 sign_gpgkey='A16BE921', sign_passphrase='*********'
             )
         """
-        if not sign_skip and not sign_gpgkey:
-            raise AptlyAPIException("Publish needs a gpgkey to sign with if sign_skip is False")
         if sign_passphrase is not None and sign_passphrase_file is not None:
             raise AptlyAPIException("Can't use sign_passphrase and sign_passphrase_file at the same time")
 
@@ -138,8 +136,6 @@ class PublishAPISection(BaseAPIClient):
                 sign_batch=True, sign_gpgkey='A16BE921', sign_passphrase='***********'
             )
         """
-        if not sign_skip and not sign_gpgkey:
-            raise AptlyAPIException("Update needs a gpgkey to sign with if sign_skip is False")
         if sign_passphrase is not None and sign_passphrase_file is not None:
             raise AptlyAPIException("Can't use sign_passphrase and sign_passphrase_file at the same time")
 


### PR DESCRIPTION
The argument 'sign_gpgkey' can be optional as aptly uses default key for publishing.