### PR TITLE
Make sign gpgkey optional

### DIFF
--- a/aptly_api/__init__.py
+++ b/aptly_api/__init__.py
@@ -12,7 +12,7 @@ from aptly_api.parts.publish import PublishEndpoint
 from aptly_api.parts.repos import Repo, FileReport
 from aptly_api.parts.snapshots import Snapshot
 
-version = "0.1.7"
+version = "0.1.6"
 
 
 __all__ = ['Client', 'AptlyAPIException', 'version', 'Package', 'PublishEndpoint', 'Repo', 'FileReport',

--- a/aptly_api/__init__.py
+++ b/aptly_api/__init__.py
@@ -12,7 +12,7 @@ from aptly_api.parts.publish import PublishEndpoint
 from aptly_api.parts.repos import Repo, FileReport
 from aptly_api.parts.snapshots import Snapshot
 
-version = "0.1.6"
+version = "0.1.7"
 
 
 __all__ = ['Client', 'AptlyAPIException', 'version', 'Package', 'PublishEndpoint', 'Repo', 'FileReport',

--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -75,8 +75,6 @@ class PublishAPISection(BaseAPIClient):
                 sign_gpgkey='A16BE921', sign_passphrase='*********'
             )
         """
-        if not sign_skip and not sign_gpgkey:
-            raise AptlyAPIException("Publish needs a gpgkey to sign with if sign_skip is False")
         if sign_passphrase is not None and sign_passphrase_file is not None:
             raise AptlyAPIException("Can't use sign_passphrase and sign_passphrase_file at the same time")
 
@@ -138,8 +136,6 @@ class PublishAPISection(BaseAPIClient):
                 sign_batch=True, sign_gpgkey='A16BE921', sign_passphrase='***********'
             )
         """
-        if not sign_skip and not sign_gpgkey:
-            raise AptlyAPIException("Update needs a gpgkey to sign with if sign_skip is False")
         if sign_passphrase is not None and sign_passphrase_file is not None:
             raise AptlyAPIException("Can't use sign_passphrase and sign_passphrase_file at the same time")
 


### PR DESCRIPTION
This is a copy of #34 on the gopythongo repo to ensure that the tests pass. #34 can't run the tests because secrets on TravisCI are not available to PRs outside of the gopythongo org.