### PR TITLE
Add explicit Optional[], use correct asserts

### DIFF
--- a/aptly_api/__init__.py
+++ b/aptly_api/__init__.py
@@ -5,12 +5,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from aptly_api.client import Client
-from aptly_api.base import AptlyAPIException
-from aptly_api.parts.packages import Package
-from aptly_api.parts.publish import PublishEndpoint
-from aptly_api.parts.repos import Repo, FileReport
-from aptly_api.parts.snapshots import Snapshot
+# explicit exports for mypy
+from aptly_api.client import Client as Client
+from aptly_api.base import AptlyAPIException as AptlyAPIException
+from aptly_api.parts.packages import Package as Package
+from aptly_api.parts.publish import PublishEndpoint as PublishEndpoint
+from aptly_api.parts.repos import Repo as Repo, FileReport as FileReport
+from aptly_api.parts.snapshots import Snapshot as Snapshot
 
 version = "0.2.0"
 

--- a/aptly_api/base.py
+++ b/aptly_api/base.py
@@ -7,7 +7,7 @@
 from typing import Sequence, Dict, Tuple, Optional, Union, List, Any, MutableMapping
 from urllib.parse import urljoin
 
-from typing.io import IO
+from typing.io import IO, BinaryIO
 
 import requests
 from requests.auth import AuthBase
@@ -54,7 +54,7 @@ class BaseAPIClient:
     def _make_url(self, path: str) -> str:
         return urljoin(self.base_url, path)
 
-    def do_get(self, urlpath: str, params: Dict[str, str] = None) -> requests.Response:
+    def do_get(self, urlpath: str, params: Optional[Dict[str, str]] = None) -> requests.Response:
         resp = requests.get(self._make_url(urlpath), params=params, verify=self.ssl_verify,
                             cert=self.ssl_cert, auth=self.http_auth, timeout=self.timeout)
 
@@ -63,16 +63,17 @@ class BaseAPIClient:
 
         return resp
 
-    def do_post(self, urlpath: str, data: Union[bytes, MutableMapping[str, str], IO[Any]] = None,
-                params: Dict[str, str] = None,
+    def do_post(self, urlpath: str, data: Union[bytes, MutableMapping[str, str], IO[Any], None] = None,
+                params: Optional[Dict[str, str]] = None,
                 files: Union[
                     Dict[str, IO],
-                    Dict[str, Tuple[str, IO, Optional[str], Optional[Dict[str, str]]]],
+                    Dict[str, Tuple[str, Union[IO, BinaryIO], Optional[str], Optional[Dict[str, str]]]],
                     Dict[str, Tuple[str, str]],
-                    Sequence[Tuple[str, IO]],
-                    Sequence[Tuple[str, IO, Optional[str], Optional[Dict[str, str]]]]
+                    Sequence[Tuple[str, Union[IO, BinaryIO]]],
+                    Sequence[Tuple[str, Union[IO, BinaryIO], Optional[str], Optional[Dict[str, str]]]],
+                    None
                 ] = None,
-                json: MutableMapping[Any, Any] = None) -> requests.Response:
+                json: Optional[MutableMapping[Any, Any]] = None) -> requests.Response:
         resp = requests.post(self._make_url(urlpath), data=data, params=params, files=files, json=json,
                              verify=self.ssl_verify, cert=self.ssl_cert, auth=self.http_auth,
                              timeout=self.timeout)
@@ -88,9 +89,10 @@ class BaseAPIClient:
                    Dict[str, Tuple[str, IO, Optional[str], Optional[Dict[str, str]]]],
                    Dict[str, Tuple[str, str]],
                    Sequence[Tuple[str, IO]],
-                   Sequence[Tuple[str, IO, Optional[str], Optional[Dict[str, str]]]]
+                   Sequence[Tuple[str, IO, Optional[str], Optional[Dict[str, str]]]],
+                   None
                ] = None,
-               json: MutableMapping[Any, Any] = None) -> requests.Response:
+               json: Optional[MutableMapping[Any, Any]] = None) -> requests.Response:
         resp = requests.put(self._make_url(urlpath), data=data, files=files, json=json,
                             verify=self.ssl_verify, cert=self.ssl_cert, auth=self.http_auth,
                             timeout=self.timeout)
@@ -100,9 +102,9 @@ class BaseAPIClient:
 
         return resp
 
-    def do_delete(self, urlpath: str, params: Dict[str, str] = None,
-                  data: Union[str, Dict[str, str], Sequence[Tuple[str, str]]] = None,
-                  json: Union[List[Dict[str, Any]], Dict[str, Any]] = None) -> requests.Response:
+    def do_delete(self, urlpath: str, params: Optional[Dict[str, str]] = None,
+                  data: Union[str, Dict[str, str], Sequence[Tuple[str, str]], None] = None,
+                  json: Union[List[Dict[str, Any]], Dict[str, Any], None] = None) -> requests.Response:
         resp = requests.delete(self._make_url(urlpath), params=params, data=data, json=json,
                                verify=self.ssl_verify, cert=self.ssl_cert, auth=self.http_auth,
                                timeout=self.timeout)

--- a/aptly_api/parts/files.py
+++ b/aptly_api/parts/files.py
@@ -4,26 +4,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
-from typing import Sequence, List, Tuple, BinaryIO, cast  # noqa: F401
+from typing import Sequence, List, Tuple, BinaryIO, cast, Optional  # noqa: F401
 
 from aptly_api.base import BaseAPIClient, AptlyAPIException
 
 
 class FilesAPISection(BaseAPIClient):
-    def list(self, directory: str = None) -> Sequence[str]:
+    def list(self, directory: Optional[str] = None) -> Sequence[str]:
         if directory is None:
             resp = self.do_get("api/files")
         else:
             resp = self.do_get("api/files/%s" % directory)
 
-        return resp.json()
+        return cast(List[str], resp.json())
 
     def upload(self, destination: str, *files: str) -> Sequence[str]:
         to_upload = []  # type: List[Tuple[str, BinaryIO]]
         for f in files:
             if not os.path.exists(f) or not os.access(f, os.R_OK):
                 raise AptlyAPIException("File to upload %s can't be opened or read" % f)
-            fh = cast(BinaryIO, open(f, mode="rb"))
+            fh = open(f, mode="rb")
             to_upload.append((f, fh),)
 
         try:
@@ -36,7 +36,7 @@ class FilesAPISection(BaseAPIClient):
                 if not to_close.closed:
                     to_close.close()
 
-        return resp.json()
+        return cast(List[str], resp.json())
 
-    def delete(self, path: str = None) -> None:
+    def delete(self, path: Optional[str] = None) -> None:
         self.do_delete("api/files/%s" % path)

--- a/aptly_api/parts/misc.py
+++ b/aptly_api/parts/misc.py
@@ -3,6 +3,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import cast
+
 from aptly_api.base import AptlyAPIException, BaseAPIClient
 
 
@@ -13,6 +15,6 @@ class MiscAPISection(BaseAPIClient):
     def version(self) -> str:
         resp = self.do_get("api/version")
         if "Version" in resp.json():
-            return resp.json()["Version"]
+            return cast(str, resp.json()["Version"])
         else:
             raise AptlyAPIException("Aptly server didn't return a valid response object:\n%s" % resp.text)

--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from typing import NamedTuple, Sequence, Dict, Union, List, cast
+from typing import NamedTuple, Sequence, Dict, Union, List, cast, Optional
 from urllib.parse import quote
 
 from aptly_api.base import BaseAPIClient, AptlyAPIException
@@ -60,11 +60,11 @@ class PublishAPISection(BaseAPIClient):
     def publish(self, *, source_kind: str = "local",
                 sources: Sequence[Dict[str, str]],
                 architectures: Sequence[str],
-                prefix: str = None, distribution: str = None, label: str = None,
-                origin: str = None, force_overwrite: bool = False,
-                sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: str = None,
-                sign_keyring: str = None, sign_secret_keyring: str = None,
-                sign_passphrase: str = None, sign_passphrase_file: str = None) -> PublishEndpoint:
+                prefix: Optional[str] = None, distribution: Optional[str] = None, label: Optional[str] = None,
+                origin: Optional[str] = None, force_overwrite: bool = False,
+                sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: Optional[str] = None,
+                sign_keyring: Optional[str] = None, sign_secret_keyring: Optional[str] = None,
+                sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None) -> PublishEndpoint:
         """
         Example:
 
@@ -123,10 +123,10 @@ class PublishAPISection(BaseAPIClient):
         return self.endpoint_from_response(resp.json())
 
     def update(self, *, prefix: str, distribution: str,
-               snapshots: Sequence[Dict[str, str]] = None, force_overwrite: bool = False,
-               sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: str = None,
-               sign_keyring: str = None, sign_secret_keyring: str = None,
-               sign_passphrase: str = None, sign_passphrase_file: str = None) -> PublishEndpoint:
+               snapshots: Optional[Sequence[Dict[str, str]]] = None, force_overwrite: bool = False,
+               sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: Optional[str] = None,
+               sign_keyring: Optional[str] = None, sign_secret_keyring: Optional[str] = None,
+               sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None) -> PublishEndpoint:
         """
         Example:
 

--- a/aptly_api/parts/repos.py
+++ b/aptly_api/parts/repos.py
@@ -39,8 +39,8 @@ class ReposAPISection(BaseAPIClient):
             report=cast(Dict[str, Sequence[str]], api_response["Report"]),
         )
 
-    def create(self, reponame: str, comment: str = None, default_distribution: str = None,
-               default_component: str = None) -> Repo:
+    def create(self, reponame: str, comment: Optional[str] = None, default_distribution: Optional[str] = None,
+               default_component: Optional[str] = None) -> Repo:
         data = {
             "Name": reponame,
         }
@@ -60,7 +60,7 @@ class ReposAPISection(BaseAPIClient):
         resp = self.do_get("api/repos/%s" % quote(reponame))
         return self.repo_from_response(resp.json())
 
-    def search_packages(self, reponame: str, query: str = None, with_deps: bool = False,
+    def search_packages(self, reponame: str, query: Optional[str] = None, with_deps: bool = False,
                         detailed: bool = False) -> Sequence[Package]:
         if query is None and with_deps:
             raise AptlyAPIException("search_packages can't include dependencies (with_deps==True) without"
@@ -81,8 +81,8 @@ class ReposAPISection(BaseAPIClient):
             ret.append(PackageAPISection.package_from_response(rpkg))
         return ret
 
-    def edit(self, reponame: str, comment: str = None, default_distribution: str = None,
-             default_component: str = None) -> Repo:
+    def edit(self, reponame: str, comment: Optional[str] = None, default_distribution: Optional[str] = None,
+             default_component: Optional[str] = None) -> Repo:
         if comment is None and default_component is None and default_distribution is None:
             raise AptlyAPIException("edit requires at least one of 'comment', 'default_distribution' or "
                                     "'default_component'.")
@@ -111,8 +111,8 @@ class ReposAPISection(BaseAPIClient):
     def delete(self, reponame: str, force: bool = False) -> None:
         self.do_delete("api/repos/%s" % quote(reponame), params={"force": "1" if force else "0"})
 
-    def add_uploaded_file(self, reponame: str, dir: str, filename: str = None, remove_processed_files: bool = True,
-                          force_replace: bool = False) -> FileReport:
+    def add_uploaded_file(self, reponame: str, dir: str, filename: Optional[str] = None,
+                          remove_processed_files: bool = True, force_replace: bool = False) -> FileReport:
         params = {
             "noRemove": "0" if remove_processed_files else "1",
         }

--- a/aptly_api/parts/snapshots.py
+++ b/aptly_api/parts/snapshots.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from datetime import datetime
-from typing import NamedTuple, Sequence, Optional, Dict, Union, cast
+from typing import NamedTuple, Sequence, Optional, Dict, Union, cast, List
 from urllib.parse import quote
 
 import iso8601
@@ -42,7 +42,7 @@ class SnapshotAPISection(BaseAPIClient):
             ret.append(self.snapshot_from_response(rsnap))
         return ret
 
-    def create_from_repo(self, reponame: str, snapshotname: str, description: str = None) -> Snapshot:
+    def create_from_repo(self, reponame: str, snapshotname: str, description: Optional[str] = None) -> Snapshot:
         body = {
             "Name": snapshotname,
         }
@@ -52,7 +52,7 @@ class SnapshotAPISection(BaseAPIClient):
         resp = self.do_post("api/repos/%s/snapshots" % quote(reponame), json=body)
         return self.snapshot_from_response(resp.json())
 
-    def create_from_packages(self, snapshotname: str, description: str = None,
+    def create_from_packages(self, snapshotname: str, description: Optional[str] = None,
                              source_snapshots: Optional[Sequence[str]] = None,
                              package_refs: Optional[Sequence[str]] = None) -> Snapshot:
         body = {
@@ -70,7 +70,8 @@ class SnapshotAPISection(BaseAPIClient):
         resp = self.do_post("api/snapshots", json=body)
         return self.snapshot_from_response(resp.json())
 
-    def update(self, snapshotname: str, newname: str = None, newdescription: str = None) -> Snapshot:
+    def update(self, snapshotname: str, newname: Optional[str] = None,
+               newdescription: Optional[str] = None) -> Snapshot:
         if newname is None and newdescription is None:
             raise AptlyAPIException("When updating a Snapshot you must at lease provide either a new name or a "
                                     "new description.")
@@ -88,7 +89,7 @@ class SnapshotAPISection(BaseAPIClient):
         resp = self.do_get("api/snapshots/%s" % quote(snapshotname))
         return self.snapshot_from_response(resp.json())
 
-    def list_packages(self, snapshotname: str, query: str = None, with_deps: bool = False,
+    def list_packages(self, snapshotname: str, query: Optional[str] = None, with_deps: bool = False,
                       detailed: bool = False) -> Sequence[Package]:
         params = {}
         if query is not None:
@@ -115,4 +116,4 @@ class SnapshotAPISection(BaseAPIClient):
 
     def diff(self, snapshot1: str, snapshot2: str) -> Sequence[Dict[str, str]]:
         resp = self.do_get("api/snapshots/%s/diff/%s" % (quote(snapshot1), quote(snapshot2),))
-        return resp.json()
+        return cast(List[Dict[str, str]], resp.json())

--- a/aptly_api/tests/files.py
+++ b/aptly_api/tests/files.py
@@ -22,15 +22,15 @@ class FilesAPISectionTests(TestCase):
 
     def test_list(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/files", text='["aptly-0.9"]')
-        self.assertListEqual(self.fapi.list(), ["aptly-0.9"])
+        self.assertSequenceEqual(self.fapi.list(), ["aptly-0.9"])
 
     def test_list_dir(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/files/dir", text='["dir/aptly_0.9~dev+217+ge5d646c_i386.deb"]')
-        self.assertListEqual(self.fapi.list("dir"), ["dir/aptly_0.9~dev+217+ge5d646c_i386.deb"])
+        self.assertSequenceEqual(self.fapi.list("dir"), ["dir/aptly_0.9~dev+217+ge5d646c_i386.deb"])
 
     def test_upload_file(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/files/test", text='["test/testpkg.deb"]')
-        self.assertListEqual(
+        self.assertSequenceEqual(
             self.fapi.upload("test", os.path.join(os.path.dirname(__file__), "testpkg.deb")),
             ['test/testpkg.deb'],
         )

--- a/aptly_api/tests/publish.py
+++ b/aptly_api/tests/publish.py
@@ -25,7 +25,7 @@ class PublishAPISectionTests(TestCase):
                        '"Origin":"","Prefix":"nightly/stretch","SkipContents":false,'
                        '"SourceKind":"local","Sources":[{"Component":"main","Name":"maurusnet"}],'
                        '"Storage":"s3:maurusnet"}]')
-        self.assertListEqual(
+        self.assertSequenceEqual(
             self.papi.list(),
             [
                 PublishEndpoint(

--- a/aptly_api/tests/repos.py
+++ b/aptly_api/tests/repos.py
@@ -48,7 +48,7 @@ class ReposAPISectionTests(TestCase):
     def test_search(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/repos/aptly-repo/packages",
                   text='["Pamd64 authserver 0.1.14~dev0-1 1cc572a93625a9c9"]')
-        self.assertListEqual(
+        self.assertSequenceEqual(
             self.rapi.search_packages("aptly-repo"),
             [
                 Package(
@@ -89,7 +89,7 @@ class ReposAPISectionTests(TestCase):
                       "Version":"0.1.14~dev0-1"
                  }]"""
         )
-        self.assertListEqual(
+        self.assertSequenceEqual(
             self.rapi.search_packages("aptly-repo", detailed=True, with_deps=True, query="Name (authserver)"),
             [
                 Package(
@@ -143,7 +143,7 @@ class ReposAPISectionTests(TestCase):
                   text='[{"Name":"maurusnet","Comment":"","DefaultDistribution":"",'
                        '"DefaultComponent":"main"},{"Name":"aptly-repo","Comment":"comment",'
                        '"DefaultDistribution":"stretch","DefaultComponent":"main"}]')
-        self.assertListEqual(
+        self.assertSequenceEqual(
             self.rapi.list(),
             [
                 Repo(name='maurusnet', comment='', default_distribution='', default_component='main'),


### PR DESCRIPTION
By default, mypy now doesn't add None as a possible value for parameters
that have a None default value. All of these have been marked as
Optional[]. Additionally the following things were added:

* Explicit casts for BinaryIO which is still detected as incompatible
  with IO.
* assertListEquals has been mostly replaced with assertSequenceEquals.
* The exports from aptly_api.__init__ have been made 'explicit' by
  adding aliases.
* In some cases where we know exactly what the return type of
  requests.Response.json() will be, I added casts to that effect.