### PR TITLE
Paramater 'skip_cleanup' for publish() added

### DIFF
--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -126,7 +126,8 @@ class PublishAPISection(BaseAPIClient):
                snapshots: Optional[Sequence[Dict[str, str]]] = None, force_overwrite: bool = False,
                sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: Optional[str] = None,
                sign_keyring: Optional[str] = None, sign_secret_keyring: Optional[str] = None,
-               sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None) -> PublishEndpoint:
+               sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None,
+               skip_cleanup: Optional[bool] = False) -> PublishEndpoint:
         """
         Example:
 
@@ -149,6 +150,8 @@ class PublishAPISection(BaseAPIClient):
 
         if force_overwrite:
             body["ForceOverwrite"] = True
+        if skip_cleanup:
+            body["SkipCleanup"] = True
 
         sign_dict = {}  # type: Dict[str, Union[bool,str]]
         if sign_skip:

--- a/aptly_api/tests/publish.py
+++ b/aptly_api/tests/publish.py
@@ -279,7 +279,8 @@ class PublishAPISectionTests(TestCase):
                 sign_batch=True,
                 sign_passphrase="123456",
                 sign_keyring="/etc/gpg-managed-keyring/pubring.pub",
-                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg"
+                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg",
+                skip_cleanup=True
             ),
             PublishEndpoint(
                 storage='s3:aptly-repo',


### PR DESCRIPTION
We have many and large repos which we manage with aptly. To avoid long waiting times when publishing, we use the switch 'SkipCleanup', e.g. 
`aptly publish update -gpg-key="XXXXXXXX" -skip-cleanup repo`
For the automatic publishing of packages via your wonderful library, I miss this switch.