### PR TITLE
expose the AcquireByHash (-acquire-by-hash) option of the publish API [copy of #61]

### DIFF
--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -17,6 +17,7 @@ PublishEndpoint = NamedTuple('PublishEndpoint', [
     ('architectures', Sequence[str]),
     ('label', str),
     ('origin', str),
+    ('acquire_by_hash', bool),
 ])
 
 
@@ -36,6 +37,7 @@ class PublishAPISection(BaseAPIClient):
             architectures=cast(List[str], api_response["Architectures"]),
             label=cast(str, api_response["Label"]),
             origin=cast(str, api_response["Origin"]),
+            acquire_by_hash=cast(bool, api_response["AcquireByHash"]),
         )
 
     @staticmethod
@@ -64,7 +66,8 @@ class PublishAPISection(BaseAPIClient):
                 origin: Optional[str] = None, force_overwrite: bool = False,
                 sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: Optional[str] = None,
                 sign_keyring: Optional[str] = None, sign_secret_keyring: Optional[str] = None,
-                sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None) -> PublishEndpoint:
+                sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None,
+                acquire_by_hash: Optional[bool] = None) -> PublishEndpoint:
         """
         Example:
 
@@ -101,6 +104,8 @@ class PublishAPISection(BaseAPIClient):
             body["Origin"] = origin
         if force_overwrite:
             body["ForceOverwrite"] = True
+        if acquire_by_hash is not None:
+            body["AcquireByHash"] = acquire_by_hash
 
         sign_dict = {}  # type: Dict[str, Union[bool,str]]
         if sign_skip:

--- a/aptly_api/tests/publish.py
+++ b/aptly_api/tests/publish.py
@@ -179,7 +179,8 @@ class PublishAPISectionTests(TestCase):
                 prefix='s3:myendpoint:test/a_1', distribution='test', label='test', origin='origin',
                 sign_batch=True, sign_gpgkey='A16BE921', sign_passphrase='*********',
                 force_overwrite=True, sign_keyring="/etc/gpg-managed-keyring/pubring.pub",
-                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg"
+                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg",
+                acquire_by_hash=False
             ),
             PublishEndpoint(
                 storage='s3:myendpoint',
@@ -206,7 +207,8 @@ class PublishAPISectionTests(TestCase):
                 prefix='s3:myendpoint:test/a_1', distribution='test', label='test', origin='origin',
                 sign_batch=True, sign_gpgkey='A16BE921', sign_passphrase_file='/root/passphrase.txt',
                 force_overwrite=True, sign_keyring="/etc/gpg-managed-keyring/pubring.pub",
-                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg"
+                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg",
+                acquire_by_hash=False
             ),
             PublishEndpoint(
                 storage='s3:myendpoint',
@@ -231,7 +233,8 @@ class PublishAPISectionTests(TestCase):
             self.papi.publish(
                 sources=[{'Name': 'aptly-repo'}], architectures=['amd64'],
                 prefix='s3:myendpoint:test/a_1', distribution='test', label='test', origin='origin',
-                sign_skip=True
+                sign_skip=True,
+                acquire_by_hash=False
             ),
             PublishEndpoint(
                 storage='s3:myendpoint',
@@ -258,7 +261,7 @@ class PublishAPISectionTests(TestCase):
                 prefix='s3:myendpoint:test/a_1', distribution='test', label='test', origin='origin',
                 sign_batch=True, sign_passphrase='*********',
                 force_overwrite=True, sign_keyring="/etc/gpg-managed-keyring/pubring.pub",
-                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg"
+                sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg",
             ),
             PublishEndpoint(
                 storage='s3:myendpoint',

--- a/aptly_api/tests/publish.py
+++ b/aptly_api/tests/publish.py
@@ -21,11 +21,10 @@ class PublishAPISectionTests(TestCase):
 
     def test_list(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/publish",
-                  text='[{"AcquireByHash":false,"Architectures":["amd64"],'
-                       '"ButAutomaticUpgrades":"","Distribution":"saltfix",'
-                       '"Label":"","NotAutomatic":"","Origin":"","Prefix":"saltmirror/buster",'
-                       '"SkipContents":false,"SourceKind":"local","Sources":[{"Component":"main",'
-                       '"Name":"saltmirror"}],"Storage":"s3:maurusnet"}]')
+                  text='[{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"mn-nightly","Label":"",'
+                       '"Origin":"","Prefix":"nightly/stretch","SkipContents":false,'
+                       '"SourceKind":"local","Sources":[{"Component":"main","Name":"maurusnet"}],'
+                       '"Storage":"s3:maurusnet"}]')
         self.assertSequenceEqual(
             self.papi.list(),
             [
@@ -40,7 +39,8 @@ class PublishAPISectionTests(TestCase):
                     }],
                     architectures=['amd64'],
                     label='',
-                    origin=''
+                    origin='',
+                    acquire_by_hash=False
                 )
             ]
         )
@@ -70,7 +70,8 @@ class PublishAPISectionTests(TestCase):
                 }],
                 architectures=['amd64'],
                 label='',
-                origin=''
+                origin='',
+                acquire_by_hash=False
             )
         )
 
@@ -99,7 +100,8 @@ class PublishAPISectionTests(TestCase):
                 }],
                 architectures=['amd64'],
                 label='',
-                origin=''
+                origin='',
+                acquire_by_hash=False
             )
         )
 
@@ -126,7 +128,8 @@ class PublishAPISectionTests(TestCase):
                 }],
                 architectures=['amd64'],
                 label='',
-                origin=''
+                origin='',
+                acquire_by_hash=False
             )
         )
 
@@ -159,7 +162,8 @@ class PublishAPISectionTests(TestCase):
                 }],
                 architectures=['amd64'],
                 label='',
-                origin=''
+                origin='',
+                acquire_by_hash=False
             )
         )
 
@@ -185,7 +189,8 @@ class PublishAPISectionTests(TestCase):
                 sources=[{'Component': 'main', 'Name': 'aptly-repo'}],
                 architectures=['amd64'],
                 label='test',
-                origin='origin'
+                origin='origin',
+                acquire_by_hash=False
             )
         )
 
@@ -211,7 +216,8 @@ class PublishAPISectionTests(TestCase):
                 sources=[{'Component': 'main', 'Name': 'aptly-repo'}],
                 architectures=['amd64'],
                 label='test',
-                origin='origin'
+                origin='origin',
+                acquire_by_hash=False
             )
         )
 
@@ -235,7 +241,8 @@ class PublishAPISectionTests(TestCase):
                 sources=[{'Component': 'main', 'Name': 'aptly-repo'}],
                 architectures=['amd64'],
                 label='test',
-                origin='origin'
+                origin='origin',
+                acquire_by_hash=False
             )
         )
 
@@ -261,7 +268,8 @@ class PublishAPISectionTests(TestCase):
                 sources=[{'Component': 'main', 'Name': 'aptly-repo'}],
                 architectures=['amd64'],
                 label='test',
-                origin='origin'
+                origin='origin',
+                acquire_by_hash=False
             )
         )
 
@@ -294,7 +302,8 @@ class PublishAPISectionTests(TestCase):
                 }],
                 architectures=['amd64'],
                 label='',
-                origin=''
+                origin='',
+                acquire_by_hash=False
             )
         )
 

--- a/aptly_api/tests/publish.py
+++ b/aptly_api/tests/publish.py
@@ -21,10 +21,11 @@ class PublishAPISectionTests(TestCase):
 
     def test_list(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/publish",
-                  text='[{"Architectures":["amd64"],"Distribution":"mn-nightly","Label":"",'
-                       '"Origin":"","Prefix":"nightly/stretch","SkipContents":false,'
-                       '"SourceKind":"local","Sources":[{"Component":"main","Name":"maurusnet"}],'
-                       '"Storage":"s3:maurusnet"}]')
+                  text='[{"AcquireByHash":false,"Architectures":["amd64"],'
+                       '"ButAutomaticUpgrades":"","Distribution":"saltfix",'
+                       '"Label":"","NotAutomatic":"","Origin":"","Prefix":"saltmirror/buster",'
+                       '"SkipContents":false,"SourceKind":"local","Sources":[{"Component":"main",'
+                       '"Name":"saltmirror"}],"Storage":"s3:maurusnet"}]')
         self.assertSequenceEqual(
             self.papi.list(),
             [
@@ -46,7 +47,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_update(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/publish/s3%3Aaptly-repo%3Atest_xyz__1/test",
-                  text='{"Architectures":["amd64"],"Distribution":"test","Label":"",'
+                  text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"",'
                        '"Origin":"","Prefix":"test/xyz_1","SkipContents":false,'
                        '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                        '"Storage":"s3:aptly-repo"}')
@@ -75,7 +76,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_update_passphrase_file(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/publish/s3%3Aaptly-repo%3Atest_xyz__1/test",
-                  text='{"Architectures":["amd64"],"Distribution":"test","Label":"",'
+                  text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"",'
                        '"Origin":"","Prefix":"test/xyz_1","SkipContents":false,'
                        '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                        '"Storage":"s3:aptly-repo"}')
@@ -104,7 +105,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_update_no_sign(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/publish/s3%3Aaptly-repo%3Atest_xyz__1/test",
-                  text='{"Architectures":["amd64"],"Distribution":"test","Label":"",'
+                  text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"",'
                        '"Origin":"","Prefix":"test/xyz_1","SkipContents":false,'
                        '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                        '"Storage":"s3:aptly-repo"}')
@@ -131,7 +132,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_update_snapshots(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/publish/s3%3Aaptly-repo%3Atest_xyz__1/test",
-                  text='{"Architectures":["amd64"],"Distribution":"test","Label":"",'
+                  text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"",'
                        '"Origin":"","Prefix":"test/xyz_1","SkipContents":false,'
                        '"SourceKind":"snapshot","Sources":[{"Component":"main","Name":"aptly-repo-1"}],'
                        '"Storage":"s3:aptly-repo"}')
@@ -164,7 +165,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_publish(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/publish/s3%3Amyendpoint%3Atest_a__1",
-                   text='{"Architectures":["amd64"],"Distribution":"test","Label":"test",'
+                   text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"test",'
                         '"Origin":"origin","Prefix":"test/a_1","SkipContents":false,'
                         '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                         '"Storage":"s3:myendpoint"}')
@@ -190,7 +191,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_publish_passphrase_file(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/publish/s3%3Amyendpoint%3Atest_a__1",
-                   text='{"Architectures":["amd64"],"Distribution":"test","Label":"test",'
+                   text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"test",'
                         '"Origin":"origin","Prefix":"test/a_1","SkipContents":false,'
                         '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                         '"Storage":"s3:myendpoint"}')
@@ -216,7 +217,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_publish_no_sign(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/publish/s3%3Amyendpoint%3Atest_a__1",
-                   text='{"Architectures":["amd64"],"Distribution":"test","Label":"test",'
+                   text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"test",'
                         '"Origin":"origin","Prefix":"test/a_1","SkipContents":false,'
                         '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                         '"Storage":"s3:myendpoint"}')
@@ -240,7 +241,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_publish_default_key(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/publish/s3%3Amyendpoint%3Atest_a__1",
-                   text='{"Architectures":["amd64"],"Distribution":"test","Label":"test",'
+                   text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"test",'
                         '"Origin":"origin","Prefix":"test/a_1","SkipContents":false,'
                         '"SourceKind":"local","Sources":[{"Component":"main","Name":"aptly-repo"}],'
                         '"Storage":"s3:myendpoint"}')
@@ -266,7 +267,7 @@ class PublishAPISectionTests(TestCase):
 
     def test_update_snapshot_default_key(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/publish/s3%3Aaptly-repo%3Atest_xyz__1/test",
-                  text='{"Architectures":["amd64"],"Distribution":"test","Label":"",'
+                  text='{"AcquireByHash":false,"Architectures":["amd64"],"Distribution":"test","Label":"",'
                        '"Origin":"","Prefix":"test/xyz_1","SkipContents":false,'
                        '"SourceKind":"snapshot","Sources":[{"Component":"main","Name":"aptly-repo-1"}],'
                        '"Storage":"s3:aptly-repo"}')


### PR DESCRIPTION
**Original description**
Publish API with the AcquireByHash option https://www.aptly.info/doc/api/publish/

**State**
This is a local copy of ANYbotics' PR #61. This also adds the necessary modifications to the test suite.