### PR TITLE
Add missing SkipContents option on publish-update endpoint

### DIFF
--- a/aptly_api/parts/publish.py
+++ b/aptly_api/parts/publish.py
@@ -132,6 +132,7 @@ class PublishAPISection(BaseAPIClient):
                sign_skip: bool = False, sign_batch: bool = True, sign_gpgkey: Optional[str] = None,
                sign_keyring: Optional[str] = None, sign_secret_keyring: Optional[str] = None,
                sign_passphrase: Optional[str] = None, sign_passphrase_file: Optional[str] = None,
+               skip_contents: Optional[bool] = False,
                skip_cleanup: Optional[bool] = False) -> PublishEndpoint:
         """
         Example:
@@ -157,6 +158,8 @@ class PublishAPISection(BaseAPIClient):
             body["ForceOverwrite"] = True
         if skip_cleanup:
             body["SkipCleanup"] = True
+        if skip_contents:
+            body["SkipContents"] = True
 
         sign_dict = {}  # type: Dict[str, Union[bool,str]]
         if sign_skip:

--- a/aptly_api/tests/test_publish.py
+++ b/aptly_api/tests/test_publish.py
@@ -292,6 +292,7 @@ class PublishAPISectionTests(TestCase):
                 sign_passphrase="123456",
                 sign_keyring="/etc/gpg-managed-keyring/pubring.pub",
                 sign_secret_keyring="/etc/gpg-managed-keyring/secring.gpg",
+                skip_contents=True,
                 skip_cleanup=True
             ),
             PublishEndpoint(


### PR DESCRIPTION
The options was published quite long ago on https://github.com/aptly-dev/aptly/pull/347 as part of the API. It allows publishing + updating a specific repository without generating the whole content usually used by apt-file. If you have a big repository with a few thousands of packages, it will improve by 50x (or even more) the publishing.