### PR TITLE
Add support for filename, content-type and headers when uploading files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: ["3.11", "3.12", "3.13"]
+                python-version: ["3.11", "3.12"]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
         branches: [ "master" ]
     pull_request:
         branches: [ "master" ]
+    workflow_dispatch:
 
 jobs:
     build:
@@ -12,7 +13,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: ["3.11", "3.12"]
+                python-version: ["3.11", "3.12", "3.13"]
 
         steps:
             - uses: actions/checkout@v4

--- a/aptly_api/__init__.py
+++ b/aptly_api/__init__.py
@@ -13,7 +13,7 @@ from aptly_api.parts.publish import PublishEndpoint as PublishEndpoint
 from aptly_api.parts.repos import Repo as Repo, FileReport as FileReport
 from aptly_api.parts.snapshots import Snapshot as Snapshot
 
-version = "0.2.4"
+version = "0.3.0"
 
 
 __all__ = ['Client', 'AptlyAPIException', 'version', 'Package', 'PublishEndpoint', 'Repo', 'FileReport',

--- a/aptly_api/client.py
+++ b/aptly_api/client.py
@@ -12,6 +12,7 @@ from aptly_api.parts.publish import PublishAPISection
 from aptly_api.parts.repos import ReposAPISection
 from aptly_api.parts.files import FilesAPISection
 from aptly_api.parts.snapshots import SnapshotAPISection
+from aptly_api.parts.mirrors import MirrorsAPISection
 
 
 class Client:
@@ -31,6 +32,8 @@ class Client:
                                      ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
         self.snapshots = SnapshotAPISection(base_url=self.__aptly_server_url, ssl_verify=ssl_verify,
                                             ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
+        self.mirrors = MirrorsAPISection(
+            base_url=self.__aptly_server_url, ssl_verify=ssl_verify, ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
 
     @property
     def aptly_server_url(self) -> str:

--- a/aptly_api/client.py
+++ b/aptly_api/client.py
@@ -32,9 +32,8 @@ class Client:
                                      ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
         self.snapshots = SnapshotAPISection(base_url=self.__aptly_server_url, ssl_verify=ssl_verify,
                                             ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
-        self.mirrors = MirrorsAPISection(
-            base_url=self.__aptly_server_url, ssl_verify=ssl_verify,
-            ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
+        self.mirrors = MirrorsAPISection(base_url=self.__aptly_server_url, ssl_verify=ssl_verify,
+                                         ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
 
     @property
     def aptly_server_url(self) -> str:

--- a/aptly_api/client.py
+++ b/aptly_api/client.py
@@ -33,7 +33,8 @@ class Client:
         self.snapshots = SnapshotAPISection(base_url=self.__aptly_server_url, ssl_verify=ssl_verify,
                                             ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
         self.mirrors = MirrorsAPISection(
-            base_url=self.__aptly_server_url, ssl_verify=ssl_verify, ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
+            base_url=self.__aptly_server_url, ssl_verify=ssl_verify,
+            ssl_cert=ssl_cert, http_auth=http_auth, timeout=timeout)
 
     @property
     def aptly_server_url(self) -> str:

--- a/aptly_api/parts/mirrors.py
+++ b/aptly_api/parts/mirrors.py
@@ -39,21 +39,22 @@ class MirrorsAPISection(BaseAPIClient):
     def mirror_from_response(api_response: Dict[str, str]) -> Mirror:
         return Mirror(
             uuid=cast(str, api_response["UUID"]) if "UUID" in api_response else None,
-            name=cast(str, api_response["Name"]), archiveurl=cast(str, api_response["ArchiveRoot"]),
+            name=cast(str, api_response["Name"]),
+            archiveurl=cast(str, api_response["ArchiveRoot"]),
             distribution=cast(str, api_response["Distribution"]) if "Distribution" in api_response else None,
-            components=cast(List[str], api_response["Components"])if "Components" in api_response else None,
+            components=cast(List[str], api_response["Components"]) if "Components" in api_response else None,
             architectures=cast(List[str], api_response["Architectures"]) if "Architectures" in api_response else None,
             meta=cast(List[Dict[str, str]], api_response["Meta"]) if "Meta" in api_response else None,
             downloaddate=cast(str, api_response["LastDownloadDate"]) if "LastDownloadDate" in api_response else None,
             filter=cast(str, api_response["Filter"]) if "Filter" in api_response else None,
-            status=cast(int, api_response["Status"])if "Status" in api_response else None,
-            worker_pid=cast(int, api_response["WorkerPID"]) if "WorkerPID" in api_response else None,
-            filter_with_deps=cast(bool, api_response["FilterWithDeps"]),
-            skip_component_check=cast(bool, api_response["SkipComponentCheck"]),
-            skip_architecture_check=cast(bool, api_response["SkipArchitectureCheck"]),
-            download_sources=cast(bool, api_response["DownloadSources"]),
-            download_udebs=cast(bool, api_response["DownloadUdebs"]),
-            download_installer=cast(bool, api_response["DownloadInstaller"])
+            status=cast(int, api_response["Status"]) if "Status" in api_response else None,
+            worker_pid=cast( int, api_response["WorkerPID"]) if "WorkerPID" in api_response else None,
+            filter_with_deps=cast(bool, api_response["FilterWithDeps"]) if "FilterWithDeps" in api_response else False,
+            skip_component_check=cast(bool, api_response["SkipComponentCheck"]) if "SkipComponentCheck" in api_response else False,
+            skip_architecture_check=cast(bool, api_response["SkipArchitectureCheck"]) if "SkipArchitectureCheck" in api_response else False,
+            download_sources=cast(bool, api_response["DownloadSources"]) if "DownloadSources" in api_response else False,
+            download_udebs=cast(bool, api_response["DownloadUdebs"]) if "DownloadUdebs" in api_response else False,
+            download_installer=cast(bool, api_response["DownloadInstaller"]) if "DownloadInstaller" in api_response else False,
         )
 
     def list(self) -> Sequence[Mirror]:
@@ -139,32 +140,37 @@ class MirrorsAPISection(BaseAPIClient):
                architectures: Optional[List[str]] = None, keyrings: Optional[List[str]] = None,
                download_sources: bool = False, download_udebs: bool = False,
                download_installer: bool = False, filter_with_deps: bool = False,
-               skip_component_check: bool = False, ignore_signatures: bool = False) -> Mirror:
+               skip_component_check: bool = False, skip_architecture_check: bool = False,
+               ignore_signatures: bool = False) -> Mirror:
         data = {
             "Name": name,
             "ArchiveURL": archiveurl
         }  # type: T_BodyDict
 
-        if ignore_signatures:
-            data["IgnoreSignatures"] = ignore_signatures
-        if keyrings:
-            data["Keyrings"] = keyrings
-        if filter:
-            data["Filter"] = filter
         if distribution:
             data["Distribution"] = distribution
+        if filter:
+            data["Filter"] = filter
         if components:
             data["Components"] = components
         if architectures:
             data["Architectures"] = architectures
+        if keyrings:
+            data["Keyrings"] = keyrings
         if download_sources:
             data["DownloadSources"] = download_sources
         if download_udebs:
             data["DownloadUdebs"] = download_udebs
         if download_installer:
             data["DownloadInstaller"] = download_installer
+        if filter_with_deps:
+            data["FilterWithDeps"] = filter_with_deps
         if skip_component_check:
             data["SkipComponentCheck"] = skip_component_check
+        if skip_architecture_check:
+            data["SkipArchitectureCheck"] = skip_architecture_check
+        if ignore_signatures:
+            data["IgnoreSignatures"] = ignore_signatures
 
         resp = self.do_post("api/mirrors", json=data)
 

--- a/aptly_api/parts/mirrors.py
+++ b/aptly_api/parts/mirrors.py
@@ -50,11 +50,16 @@ class MirrorsAPISection(BaseAPIClient):
             status=cast(int, api_response["Status"]) if "Status" in api_response else None,
             worker_pid=cast( int, api_response["WorkerPID"]) if "WorkerPID" in api_response else None,
             filter_with_deps=cast(bool, api_response["FilterWithDeps"]) if "FilterWithDeps" in api_response else False,
-            skip_component_check=cast(bool, api_response["SkipComponentCheck"]) if "SkipComponentCheck" in api_response else False,
-            skip_architecture_check=cast(bool, api_response["SkipArchitectureCheck"]) if "SkipArchitectureCheck" in api_response else False,
-            download_sources=cast(bool, api_response["DownloadSources"]) if "DownloadSources" in api_response else False,
-            download_udebs=cast(bool, api_response["DownloadUdebs"]) if "DownloadUdebs" in api_response else False,
-            download_installer=cast(bool, api_response["DownloadInstaller"]) if "DownloadInstaller" in api_response else False,
+            skip_component_check=cast(bool, api_response["SkipComponentCheck"]
+                                      ) if "SkipComponentCheck" in api_response else False,
+            skip_architecture_check=cast(bool, api_response["SkipArchitectureCheck"]
+                                         ) if "SkipArchitectureCheck" in api_response else False,
+            download_sources=cast(bool, api_response["DownloadSources"]
+                                  ) if "DownloadSources" in api_response else False,
+            download_udebs=cast(bool, api_response["DownloadUdebs"]
+                                ) if "DownloadUdebs" in api_response else False,
+            download_installer=cast(bool, api_response["DownloadInstaller"]
+                                    ) if "DownloadInstaller" in api_response else False,
         )
 
     def list(self) -> Sequence[Mirror]:

--- a/aptly_api/parts/mirrors.py
+++ b/aptly_api/parts/mirrors.py
@@ -48,7 +48,7 @@ class MirrorsAPISection(BaseAPIClient):
             downloaddate=cast(str, api_response["LastDownloadDate"]) if "LastDownloadDate" in api_response else None,
             filter=cast(str, api_response["Filter"]) if "Filter" in api_response else None,
             status=cast(int, api_response["Status"]) if "Status" in api_response else None,
-            worker_pid=cast( int, api_response["WorkerPID"]) if "WorkerPID" in api_response else None,
+            worker_pid=cast(int, api_response["WorkerPID"]) if "WorkerPID" in api_response else None,
             filter_with_deps=cast(bool, api_response["FilterWithDeps"]) if "FilterWithDeps" in api_response else False,
             skip_component_check=cast(bool, api_response["SkipComponentCheck"]
                                       ) if "SkipComponentCheck" in api_response else False,

--- a/aptly_api/parts/mirrors.py
+++ b/aptly_api/parts/mirrors.py
@@ -38,35 +38,19 @@ class MirrorsAPISection(BaseAPIClient):
     @staticmethod
     def mirror_from_response(api_response: Dict[str, str]) -> Mirror:
         return Mirror(
-            uuid=cast(str, api_response["UUID"]
-                      ) if "UUID" in api_response else None,
-            name=cast(str, api_response["Name"]),
-            archiveurl=cast(
-                str, api_response["ArchiveRoot"]),
-            distribution=cast(
-                str, api_response["Distribution"])
-            if "Distribution" in api_response else None,
-            components=cast(List[str], api_response["Components"]
-                            )if "Components" in api_response else None,
-            architectures=cast(List[str], api_response["Architectures"]
-                               ) if "Architectures" in api_response else None,
-            meta=cast(List[Dict[str, str]], api_response["Meta"]
-                      ) if "Meta" in api_response else None,
-            downloaddate=cast(
-                str, api_response["LastDownloadDate"])
-            if "LastDownloadDate" in api_response else None,
-            filter=cast(str, api_response["Filter"]
-                        ) if "Filter" in api_response else None,
-            status=cast(int, api_response["Status"]
-                        )if "Status" in api_response else None,
-            worker_pid=cast(
-                int, api_response["WorkerPID"])
-            if "WorkerPID" in api_response else None,
+            uuid=cast(str, api_response["UUID"]) if "UUID" in api_response else None,
+            name=cast(str, api_response["Name"]), archiveurl=cast(str, api_response["ArchiveRoot"]),
+            distribution=cast(str, api_response["Distribution"]) if "Distribution" in api_response else None,
+            components=cast(List[str], api_response["Components"])if "Components" in api_response else None,
+            architectures=cast(List[str], api_response["Architectures"]) if "Architectures" in api_response else None,
+            meta=cast(List[Dict[str, str]], api_response["Meta"]) if "Meta" in api_response else None,
+            downloaddate=cast(str, api_response["LastDownloadDate"]) if "LastDownloadDate" in api_response else None,
+            filter=cast(str, api_response["Filter"]) if "Filter" in api_response else None,
+            status=cast(int, api_response["Status"])if "Status" in api_response else None,
+            worker_pid=cast(int, api_response["WorkerPID"]) if "WorkerPID" in api_response else None,
             filter_with_deps=cast(bool, api_response["FilterWithDeps"]),
-            skip_component_check=cast(
-                bool, api_response["SkipComponentCheck"]),
-            skip_architecture_check=cast(
-                bool, api_response["SkipArchitectureCheck"]),
+            skip_component_check=cast(bool, api_response["SkipComponentCheck"]),
+            skip_architecture_check=cast(bool, api_response["SkipArchitectureCheck"]),
             download_sources=cast(bool, api_response["DownloadSources"]),
             download_udebs=cast(bool, api_response["DownloadUdebs"]),
             download_installer=cast(bool, api_response["DownloadInstaller"])
@@ -77,9 +61,7 @@ class MirrorsAPISection(BaseAPIClient):
 
         mirrors = []
         for mirr in resp.json():
-            mirrors.append(
-                self.mirror_from_response(mirr)
-            )
+            mirrors.append(self.mirror_from_response(mirr))
         return mirrors
 
     def update(self, name: str, ignore_signatures: bool = False) -> None:
@@ -130,7 +112,6 @@ class MirrorsAPISection(BaseAPIClient):
 
     def show(self, name: str) -> Mirror:
         resp = self.do_get("api/mirrors/%s" % (quote(name)))
-
         return self.mirror_from_response(resp.json())
 
     def list_packages(self, name: str, query: Optional[str] = None, with_deps: bool = False,

--- a/aptly_api/parts/mirrors.py
+++ b/aptly_api/parts/mirrors.py
@@ -3,10 +3,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from typing import NamedTuple, Sequence, Dict, Union, cast, Optional, List
+from typing import NamedTuple, Sequence, Dict, cast, Optional, List
 from urllib.parse import quote
 
-from aptly_api.base import BaseAPIClient, AptlyAPIException
+from aptly_api.base import BaseAPIClient
 from aptly_api.parts.packages import Package, PackageAPISection
 
 
@@ -41,7 +41,8 @@ class MirrorsAPISection(BaseAPIClient):
             archiveurl=cast(
                 str, api_response["ArchiveRoot"]),
             distribution=cast(
-                str, api_response["Distribution"]) if "Distribution" in api_response else None,
+                str, api_response["Distribution"])
+            if "Distribution" in api_response else None,
             components=cast(List[str], api_response["Components"]
                             )if "Components" in api_response else None,
             architectures=cast(List[str], api_response["Architectures"]
@@ -49,13 +50,15 @@ class MirrorsAPISection(BaseAPIClient):
             meta=cast(List[Dict[str, str]], api_response["Meta"]
                       ) if "Meta" in api_response else None,
             downloaddate=cast(
-                str, api_response["LastDownloadDate"]) if "LastDownloadDate" in api_response else None,
+                str, api_response["LastDownloadDate"])
+            if "LastDownloadDate" in api_response else None,
             filter=cast(str, api_response["Filter"]
                         ) if "Filter" in api_response else None,
             status=cast(int, api_response["Status"]
                         )if "Status" in api_response else None,
             worker_pid=cast(
-                int, api_response["WorkerPID"])if "WorkerPID" in api_response else None,
+                int, api_response["WorkerPID"])
+            if "WorkerPID" in api_response else None,
             filter_with_deps=cast(bool, api_response["FilterWithDeps"]),
             skip_component_check=cast(
                 bool, api_response["SkipComponentCheck"]),

--- a/aptly_api/parts/mirrors.py
+++ b/aptly_api/parts/mirrors.py
@@ -13,14 +13,14 @@ from aptly_api.parts.packages import Package, PackageAPISection
 Mirror = NamedTuple('Mirror', [
     ('uuid', str),
     ('name', str),
-    ('archiveroot', str),
+    ('archiveurl', str),
     ('distribution', str),
     ('components', Sequence[str]),
     ('architectures', Sequence[str]),
     ('meta', Sequence[Dict[str, str]]),
     ('downloaddate', str),
     ('filter', str),
-    ('status', str),
+    ('status', int),
     ('worker_pid', int),
     ('filter_with_deps', bool),
     ('skip_component_check', bool),
@@ -35,17 +35,27 @@ class MirrorsAPISection(BaseAPIClient):
     @staticmethod
     def mirror_from_response(api_response: Dict[str, str]) -> Mirror:
         return Mirror(
-            uuid=cast(str, api_response["UUID"]),
+            uuid=cast(str, api_response["UUID"]
+                      ) if "UUID" in api_response else None,
             name=cast(str, api_response["Name"]),
-            archiveroot=cast(str, api_response["ArchiveRoot"]),
-            distribution=cast(str, api_response["Distribution"]),
-            components=cast(List[str], api_response["Components"]),
-            architectures=cast(List[str], api_response["Architectures"]),
-            meta=cast(List[Dict[str, str]], api_response["Meta"]),
-            downloaddate=cast(str, api_response["LastDownloadDate"]),
-            filter=cast(str, api_response["Filter"]),
-            status=cast(str, api_response["Status"]),
-            worker_pid=cast(int, api_response["WorkerPID"]),
+            archiveurl=cast(
+                str, api_response["ArchiveRoot"]),
+            distribution=cast(
+                str, api_response["Distribution"]) if "Distribution" in api_response else None,
+            components=cast(List[str], api_response["Components"]
+                            )if "Components" in api_response else None,
+            architectures=cast(List[str], api_response["Architectures"]
+                               ) if "Architectures" in api_response else None,
+            meta=cast(List[Dict[str, str]], api_response["Meta"]
+                      ) if "Meta" in api_response else None,
+            downloaddate=cast(
+                str, api_response["LastDownloadDate"]) if "LastDownloadDate" in api_response else None,
+            filter=cast(str, api_response["Filter"]
+                        ) if "Filter" in api_response else None,
+            status=cast(int, api_response["Status"]
+                        )if "Status" in api_response else None,
+            worker_pid=cast(
+                int, api_response["WorkerPID"])if "WorkerPID" in api_response else None,
             filter_with_deps=cast(bool, api_response["FilterWithDeps"]),
             skip_component_check=cast(
                 bool, api_response["SkipComponentCheck"]),
@@ -73,7 +83,7 @@ class MirrorsAPISection(BaseAPIClient):
         resp = self.do_put("api/mirrors/%s" % (quote(name)), json=body)
         return resp
 
-    def edit(self, name: str, newname: Optional[str] = None, archiveroot: Optional[str] = None,
+    def edit(self, name: str, newname: Optional[str] = None, archiveurl: Optional[str] = None,
              filter: Optional[str] = None, architectures: Optional[List[str]] = None,
              components: Optional[List[str]] = None, keyrings: Optional[List[str]] = None,
              filter_with_deps: bool = False, skip_existing_packages: bool = False,
@@ -84,8 +94,8 @@ class MirrorsAPISection(BaseAPIClient):
         body = {}
         if newname:
             body["Name"] = newname
-        if archiveroot:
-            body["ArchiveURL"] = archiveroot
+        if archiveurl:
+            body["ArchiveURL"] = archiveurl
         if filter:
             body["Filter"] = filter
         if architectures:
@@ -140,7 +150,7 @@ class MirrorsAPISection(BaseAPIClient):
         resp = self.do_delete("api/mirrors/%s" % quote(name))
         return resp
 
-    def create(self, name: str, archiveroot: str, distribution: Optional[str] = None,
+    def create(self, name: str, archiveurl: str, distribution: Optional[str] = None,
                filter: Optional[str] = None, components: Optional[List[str]] = None,
                architectures: Optional[List[str]] = None, keyrings: Optional[List[str]] = None,
                download_sources: bool = False, download_udebs: bool = False,
@@ -148,7 +158,7 @@ class MirrorsAPISection(BaseAPIClient):
                skip_component_check: bool = False, ignore_signatures: bool = False) -> Mirror:
         data = {
             "Name": name,
-            "ArchiveURL": archiveroot
+            "ArchiveURL": archiveurl
         }
 
         if ignore_signatures:

--- a/aptly_api/parts/snapshots.py
+++ b/aptly_api/parts/snapshots.py
@@ -56,6 +56,9 @@ class SnapshotAPISection(BaseAPIClient):
         body = {
             "Name": snapshotname
         }
+        if description is not None:
+            body["Description"] = description
+
         resp = self.do_post("api/mirrors/%s/snapshots" %
                             quote(mirrorname), json=body)
         return self.snapshot_from_response(resp.json())

--- a/aptly_api/parts/snapshots.py
+++ b/aptly_api/parts/snapshots.py
@@ -12,7 +12,6 @@ import iso8601
 
 from aptly_api.base import BaseAPIClient, AptlyAPIException
 from aptly_api.parts.packages import Package, PackageAPISection
-from aptly_api.parts.mirrors import Mirror
 
 Snapshot = NamedTuple('Snapshot', [
     ('name', str),

--- a/aptly_api/parts/snapshots.py
+++ b/aptly_api/parts/snapshots.py
@@ -49,8 +49,7 @@ class SnapshotAPISection(BaseAPIClient):
         if description is not None:
             body["Description"] = description
 
-        resp = self.do_post("api/repos/%s/snapshots" %
-                            quote(reponame), json=body)
+        resp = self.do_post("api/repos/%s/snapshots" % quote(reponame), json=body)
         return self.snapshot_from_response(resp.json())
 
     def create_from_mirror(self, mirrorname: str, snapshotname: str, description: Optional[str] = None) -> Snapshot:

--- a/aptly_api/tests/__init__.py
+++ b/aptly_api/tests/__init__.py
@@ -12,4 +12,4 @@ from .test_packages import *  # noqa
 from .test_publish import *  # noqa
 from .test_repos import *  # noqa
 from .test_snapshots import *  # noqa
-from .test_mirrors import *
+from .test_mirrors import *  # noqa

--- a/aptly_api/tests/__init__.py
+++ b/aptly_api/tests/__init__.py
@@ -12,3 +12,4 @@ from .test_packages import *  # noqa
 from .test_publish import *  # noqa
 from .test_repos import *  # noqa
 from .test_snapshots import *  # noqa
+from .test_mirrors import *

--- a/aptly_api/tests/test_files.py
+++ b/aptly_api/tests/test_files.py
@@ -45,6 +45,14 @@ class FilesAPISectionTests(TestCase):
         with self.assertRaises(AptlyAPIException):
             self.fapi.upload("test", os.path.join(os.path.dirname(__file__), "testpkg.deb"))
 
+    def test_upload_with_tuples(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.post("http://test/api/files/test", text='["test/otherpkg.deb", "test/binpkg.deb"]')
+        with open(os.path.join(os.path.dirname(__file__), "testpkg.deb"), "rb") as pkgf:
+            self.assertSequenceEqual(
+                self.fapi.upload("test", ("otherpkg.deb", pkgf), ("binpkg.deb", b"dpkg-contents")),
+                ['test/otherpkg.deb', 'test/binpkg.deb'],
+            )
+
     def test_delete(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.delete("http://test/api/files/test",
                      text='{}')

--- a/aptly_api/tests/test_mirrors.py
+++ b/aptly_api/tests/test_mirrors.py
@@ -8,7 +8,6 @@ from unittest.case import TestCase
 
 import requests_mock
 
-from aptly_api.base import AptlyAPIException
 from aptly_api.parts.packages import Package
 from aptly_api.parts.mirrors import MirrorsAPISection, Mirror
 
@@ -21,7 +20,21 @@ class MirrorsAPISectionTests(TestCase):
 
     def test_create(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/mirrors",
-                   text='{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb", "Name": "aptly-mirror", "ArchiveRoot": "https://deb.nodesource.com/node_10.x/", "Distribution": "bionic", "Components": ["main"], "Architectures": ["amd64"], "Meta": {"Architectures": "i386 amd64 armhf arm64", "Codename": "bionic", "Components": "main", "Date": "Tue, 06 Apr 2021 21:05:41 UTC","Description": " Apt Repository for the Node.JS 10.x Branch", "Label": "Node Source", "Origin": "Node Source"}, "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "test", "Status": 0, "WorkerPID": 0, "FilterWithDeps": true, "SkipComponentCheck": true, "SkipArchitectureCheck": true, "DownloadSources": true, "DownloadUdebs": true, "DownloadInstaller": true}'
+                   text="""{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb",
+                   "Name": "aptly-mirror",
+                   "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
+                   "Distribution": "bionic", "Components": ["main"],
+                   "Architectures": ["amd64"],
+                   "Meta": {"Architectures": "i386 amd64 armhf arm64",
+                   "Codename": "bionic", "Components": "main",
+                   "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                   "Description": " Apt Repository for the Node.JS 10.x Branch",
+                   "Label": "Node Source", "Origin": "Node Source"},
+                   "LastDownloadDate": "0001-01-01T00:00:00Z",
+                   "Filter": "test", "Status": 0, "WorkerPID": 0,
+                   "FilterWithDeps": true, "SkipComponentCheck": true,
+                   "SkipArchitectureCheck": true, "DownloadSources": true,
+                   "DownloadUdebs": true, "DownloadInstaller": true}"""
                    )
         self.assertEqual(
             self.mapi.create(name="aptly-mirror", archiveurl='https://deb.nodesource.com/node_10.x/',
@@ -60,7 +73,21 @@ class MirrorsAPISectionTests(TestCase):
 
     def test_list(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/mirrors",
-                  text='[{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb", "Name": "aptly-mirror", "ArchiveRoot": "https://deb.nodesource.com/node_10.x/", "Distribution": "bionic", "Components": ["main"], "Architectures": ["amd64"], "Meta": {"Architectures": "i386 amd64 armhf arm64", "Codename": "bionic", "Components": "main", "Date": "Tue, 06 Apr 2021 21:05:41 UTC","Description": " Apt Repository for the Node.JS 10.x Branch", "Label": "Node Source", "Origin": "Node Source"}, "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "", "Status": 0, "WorkerPID": 0, "FilterWithDeps": false, "SkipComponentCheck": false, "SkipArchitectureCheck": false, "DownloadSources": false, "DownloadUdebs": false, "DownloadInstaller": false}]'
+                  text="""[{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb",
+                  "Name": "aptly-mirror",
+                  "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
+                  "Distribution": "bionic", "Components": ["main"],
+                  "Architectures": ["amd64"],
+                  "Meta": {"Architectures": "i386 amd64 armhf arm64",
+                  "Codename": "bionic", "Components": "main",
+                  "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                  "Description": " Apt Repository for the Node.JS 10.x Branch",
+                  "Label": "Node Source", "Origin": "Node Source"},
+                  "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
+                  "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
+                  "SkipComponentCheck": false, "SkipArchitectureCheck": false,
+                  "DownloadSources": false, "DownloadUdebs": false,
+                  "DownloadInstaller": false}]"""
                   )
         self.assertSequenceEqual(
             self.mapi.list(),
@@ -95,7 +122,21 @@ class MirrorsAPISectionTests(TestCase):
 
     def test_show(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/mirrors/aptly-mirror",
-                  text='{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb", "Name": "aptly-mirror", "ArchiveRoot": "https://deb.nodesource.com/node_10.x/", "Distribution": "bionic", "Components": ["main"], "Architectures": ["amd64"], "Meta": {"Architectures": "i386 amd64 armhf arm64", "Codename": "bionic", "Components": "main", "Date": "Tue, 06 Apr 2021 21:05:41 UTC","Description": " Apt Repository for the Node.JS 10.x Branch", "Label": "Node Source", "Origin": "Node Source"}, "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "", "Status": 0, "WorkerPID": 0, "FilterWithDeps": false, "SkipComponentCheck": false, "SkipArchitectureCheck": false, "DownloadSources": false, "DownloadUdebs": false, "DownloadInstaller": false}'
+                  text="""{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb",
+                  "Name": "aptly-mirror",
+                  "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
+                  "Distribution": "bionic", "Components": ["main"],
+                  "Architectures": ["amd64"],
+                  "Meta": {"Architectures": "i386 amd64 armhf arm64",
+                  "Codename": "bionic", "Components": "main",
+                  "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                  "Description": " Apt Repository for the Node.JS 10.x Branch",
+                  "Label": "Node Source", "Origin": "Node Source"},
+                  "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
+                  "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
+                  "SkipComponentCheck": false, "SkipArchitectureCheck": false,
+                  "DownloadSources": false, "DownloadUdebs": false,
+                  "DownloadInstaller": false}"""
                   )
         self.assertEqual(
             self.mapi.show(name="aptly-mirror"),
@@ -148,8 +189,9 @@ class MirrorsAPISectionTests(TestCase):
             text="""[{
                       "Architecture":"amd64",
                       "Conflicts": "nodejs-dev, nodejs-legacy, npm",
-                      "Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4), libstdc++6 (>= 4.4.0), python-minimal, ca-certificates",
-                      "Description":"Node.js event-based server-side javascript engine\\n",
+                      "Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4),"""
+            """ libstdc++6 (>= 4.4.0), python-minimal, ca-certificates",
+                      "Description":" Node.js event-based server-side javascript engine\\n",
                       "Filename":"nodejs_10.24.1-1nodesource1_amd64.deb",
                       "FilesHash":"1f74a6abf6acc572",
                       "Homepage":"https://nodejs.org",
@@ -163,7 +205,8 @@ class MirrorsAPISectionTests(TestCase):
                       "Provides":"nodejs-dev, nodejs-legacy, npm",
                       "SHA1":"a3bc5a29614eab366bb3644abb1e602b5c8953d5",
                       "SHA256":"4b374d16b536cf1a3963ddc4575ed2b68b28b0b5ea6eefe93c942dfc0ed35177",
-                      "SHA512":"bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f07969ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460",
+                      "SHA512":"bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f0796"""
+            """9ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460",
                       "Section":"web",
                       "ShortKey":"Pamd64 nodejs 10.24.1-1nodesource1",
                       "Size":"15949164",
@@ -179,10 +222,11 @@ class MirrorsAPISectionTests(TestCase):
                     short_key='Pamd64 nodejs 10.24.1-1nodesource1',
                     files_hash='1f74a6abf6acc572',
                     fields={
-                        'Architecture': 'amd64',
+                        "Architecture": "amd64",
                         'Conflicts': 'nodejs-dev, nodejs-legacy, npm',
-                        'Depends': '1libc6 (>= 2.9), libgcc1 (>= 1:3.4), libstdc++6 (>= 4.4.0), python-minimal, ca-certificates',
-                        'Description': 'Node.js event-based server-side javascript engine\n',
+                        'Depends': '1libc6 (>= 2.9), libgcc1 (>= 1:3.4), '
+                        'libstdc++6 (>= 4.4.0), python-minimal, ca-certificates',
+                        'Description': ' Node.js event-based server-side javascript engine\n',
                         'Filename': 'nodejs_10.24.1-1nodesource1_amd64.deb',
                         'FilesHash': '1f74a6abf6acc572',
                         'Homepage': 'https://nodejs.org',
@@ -197,7 +241,7 @@ class MirrorsAPISectionTests(TestCase):
                         'SHA1': 'a3bc5a29614eab366bb3644abb1e602b5c8953d5',
                         'SHA256': '4b374d16b536cf1a3963ddc4575ed2b68b28b0b5ea6eefe93c942dfc0ed35177',
                         'SHA512': 'bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f0796'
-                                  '9ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460',
+                        '9ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460',
                         'Section': 'web',
                         'ShortKey': 'Pamd64 nodejs 10.24.1-1nodesource1',
                         'Size': '15949164',

--- a/aptly_api/tests/test_mirrors.py
+++ b/aptly_api/tests/test_mirrors.py
@@ -21,29 +21,30 @@ class MirrorsAPISectionTests(TestCase):
     def test_create(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/mirrors",
                    text="""{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb",
-                   "Name": "aptly-mirror",
-                   "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
-                   "Distribution": "bionic", "Components": ["main"],
-                   "Architectures": ["amd64"],
-                   "Meta": [{"Architectures": "i386 amd64 armhf arm64",
-                   "Codename": "bionic", "Components": "main",
-                   "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
-                   "Description": " Apt Repository for the Node.JS 10.x Branch",
-                   "Label": "Node Source", "Origin": "Node Source"}],
-                   "LastDownloadDate": "0001-01-01T00:00:00Z",
-                   "Filter": "test", "Status": 0, "WorkerPID": 0,
-                   "FilterWithDeps": true, "SkipComponentCheck": true,
-                   "SkipArchitectureCheck": true, "DownloadSources": true,
-                   "DownloadUdebs": true, "DownloadInstaller": true}"""
-                   )
+                        "Name": "aptly-mirror",
+                        "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
+                        "Distribution": "bionic", "Components": ["main"],
+                        "Architectures": ["amd64"],
+                        "Meta": [{"Architectures": "i386 amd64 armhf arm64",
+                        "Codename": "bionic", "Components": "main",
+                        "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                        "Description": " Apt Repository for the Node.JS 10.x Branch",
+                        "Label": "Node Source", "Origin": "Node Source"}],
+                        "LastDownloadDate": "0001-01-01T00:00:00Z",
+                        "Filter": "test", "Status": 0, "WorkerPID": 0,
+                        "FilterWithDeps": true, "SkipComponentCheck": true,
+                        "SkipArchitectureCheck": true, "DownloadSources": true,
+                        "DownloadUdebs": true, "DownloadInstaller": true}""")
         self.assertSequenceEqual(
-            self.miapi.create(name="aptly-mirror", archiveurl='https://deb.nodesource.com/node_10.x/',
-                              distribution='bionic', components=["main"],
-                              architectures=["amd64"],
-                              filter="test", download_udebs=True,
-                              download_sources=True, download_installer=True,
-                              skip_component_check=True, filter_with_deps=True,
-                              keyrings=["/path/to/keyring"], ignore_signatures=True),
+            self.miapi.create(
+                name="aptly-mirror", archiveurl='https://deb.nodesource.com/node_10.x/',
+                distribution='bionic', components=["main"],
+                architectures=["amd64"],
+                filter="test", download_udebs=True,
+                download_sources=True, download_installer=True,
+                skip_component_check=True, filter_with_deps=True,
+                keyrings=["/path/to/keyring"], ignore_signatures=True
+            ),
             Mirror(
                 uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
                 name="aptly-mirror",
@@ -67,28 +68,26 @@ class MirrorsAPISectionTests(TestCase):
                 download_sources=True,
                 download_udebs=True,
                 download_installer=True
-
             )
         )
 
     def test_list(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/mirrors",
                   text="""[{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb",
-                  "Name": "aptly-mirror",
-                  "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
-                  "Distribution": "bionic", "Components": ["main"],
-                  "Architectures": ["amd64"],
-                  "Meta": [{"Architectures": "i386 amd64 armhf arm64",
-                  "Codename": "bionic", "Components": "main",
-                  "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
-                  "Description": " Apt Repository for the Node.JS 10.x Branch",
-                  "Label": "Node Source", "Origin": "Node Source"}],
-                  "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
-                  "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
-                  "SkipComponentCheck": false, "SkipArchitectureCheck": false,
-                  "DownloadSources": false, "DownloadUdebs": false,
-                  "DownloadInstaller": false}]"""
-                  )
+                       "Name": "aptly-mirror",
+                       "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
+                       "Distribution": "bionic", "Components": ["main"],
+                       "Architectures": ["amd64"],
+                       "Meta": [{"Architectures": "i386 amd64 armhf arm64",
+                       "Codename": "bionic", "Components": "main",
+                       "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                       "Description": " Apt Repository for the Node.JS 10.x Branch",
+                       "Label": "Node Source", "Origin": "Node Source"}],
+                       "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
+                       "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
+                       "SkipComponentCheck": false, "SkipArchitectureCheck": false,
+                       "DownloadSources": false, "DownloadUdebs": false,
+                       "DownloadInstaller": false}]""")
         self.assertSequenceEqual(
             self.miapi.list(),
             [
@@ -123,21 +122,20 @@ class MirrorsAPISectionTests(TestCase):
     def test_show(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get("http://test/api/mirrors/aptly-mirror",
                   text="""{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb",
-                  "Name": "aptly-mirror",
-                  "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
-                  "Distribution": "bionic", "Components": ["main"],
-                  "Architectures": ["amd64"],
-                  "Meta": [{"Architectures": "i386 amd64 armhf arm64",
-                  "Codename": "bionic", "Components": "main",
-                  "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
-                  "Description": " Apt Repository for the Node.JS 10.x Branch",
-                  "Label": "Node Source", "Origin": "Node Source"}],
-                  "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
-                  "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
-                  "SkipComponentCheck": false, "SkipArchitectureCheck": false,
-                  "DownloadSources": false, "DownloadUdebs": false,
-                  "DownloadInstaller": false}"""
-                  )
+                       "Name": "aptly-mirror",
+                       "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
+                       "Distribution": "bionic", "Components": ["main"],
+                       "Architectures": ["amd64"],
+                       "Meta": [{"Architectures": "i386 amd64 armhf arm64",
+                       "Codename": "bionic", "Components": "main",
+                       "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                       "Description": " Apt Repository for the Node.JS 10.x Branch",
+                       "Label": "Node Source", "Origin": "Node Source"}],
+                       "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
+                       "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
+                       "SkipComponentCheck": false, "SkipArchitectureCheck": false,
+                       "DownloadSources": false, "DownloadUdebs": false,
+                       "DownloadInstaller": false}""")
         self.assertSequenceEqual(
             self.miapi.show(name="aptly-mirror"),
             Mirror(
@@ -186,33 +184,28 @@ class MirrorsAPISectionTests(TestCase):
     def test_list_packages_details(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.get(
             "http://test/api/mirrors/aptly-mirror/packages?format=details",
-            text="""[{
-                      "Architecture":"amd64",
-                      "Conflicts": "nodejs-dev, nodejs-legacy, npm",
-                      "Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4),"""
-            """ libstdc++6 (>= 4.4.0), python-minimal, ca-certificates",
-                      "Description":" Node.js event-based server-side javascript engine\\n",
-                      "Filename":"nodejs_10.24.1-1nodesource1_amd64.deb",
-                      "FilesHash":"1f74a6abf6acc572",
-                      "Homepage":"https://nodejs.org",
-                      "Installed-Size":"78630",
-                      "Key":"Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572",
-                      "License":"unknown",
-                      "MD5sum":"6d9f0e30396cb6c20945ff6de2f9f322",
-                      "Maintainer":"Ivan Iguaran <ivan@nodesource.com>",
-                      "Package":"nodejs",
-                      "Priority":"optional",
-                      "Provides":"nodejs-dev, nodejs-legacy, npm",
-                      "SHA1":"a3bc5a29614eab366bb3644abb1e602b5c8953d5",
-                      "SHA256":"4b374d16b536cf1a3963ddc4575ed2b68b28b0b5ea6eefe93c942dfc0ed35177",
-                      "SHA512":"bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f0796"""
-            """9ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460",
-                      "Section":"web",
-                      "ShortKey":"Pamd64 nodejs 10.24.1-1nodesource1",
-                      "Size":"15949164",
-                      "Version":"10.24.1-1nodesource1"
-                 }]"""
-        )
+            text='[{"Architecture":"amd64",'
+                 '"Conflicts": "nodejs-dev, nodejs-legacy, npm",'
+                 '"Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4),'
+                 'libstdc++6 (>= 4.4.0), python-minimal, ca-certificates",'
+                 '"Description":" Node.js event-based server-side javascript engine\\n",'
+                 '"Filename":"nodejs_10.24.1-1nodesource1_amd64.deb",'
+                 '"FilesHash":"1f74a6abf6acc572",'
+                 '"Homepage":"https://nodejs.org",'
+                 '"Installed-Size":"78630", "Key":"Pamd64 nodejs 10.24.1-1nodesource11f74a6abf6acc572",'
+                 '"License":"unknown",'
+                 '"MD5sum":"6d9f0e30396cb6c20945ff6de2f9f322","Maintainer":"Ivan Iguaran <ivan@nodesource.com>",'
+                 '"Package":"nodejs",'
+                 '"Priority":"optional",'
+                 '"Provides":"nodejs-dev, nodejs-legacy, npm",'
+                 '"SHA1":"a3bc5a29614eab366bb3644abb1e602b5c8953d5",'
+                 '"SHA256":"4b374d16b536cf1a3963ddc4575ed2b68b28b0b5ea6eefe93c942dfc0ed35177",'
+                 '"SHA512":"bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f0796'
+                 '9ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460",'
+                 '"Section":"web",'
+                 '"ShortKey":"Pamd64 nodejs 10.24.1-1nodesource1",'
+                 '"Size":"15949164",'
+                 'Version":"10.24.1-1nodesource1"}]')
         self.assertSequenceEqual(
             self.miapi.list_packages(
                 "aptly-mirror", detailed=True, with_deps=True, query="nodejs"),

--- a/aptly_api/tests/test_mirrors.py
+++ b/aptly_api/tests/test_mirrors.py
@@ -1,0 +1,240 @@
+# -* encoding: utf-8 *-
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import Any
+from unittest.case import TestCase
+
+import requests_mock
+
+from aptly_api.base import AptlyAPIException
+from aptly_api.parts.packages import Package
+from aptly_api.parts.mirrors import MirrorsAPISection, Mirror
+
+
+@requests_mock.Mocker(kw='rmock')
+class MirrorsAPISectionTests(TestCase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self.mapi = MirrorsAPISection("http://test/")
+
+    def test_create(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.post("http://test/api/mirrors",
+                   text='{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb", "Name": "aptly-mirror", "ArchiveRoot": "https://deb.nodesource.com/node_10.x/", "Distribution": "bionic", "Components": ["main"], "Architectures": ["amd64"], "Meta": {"Architectures": "i386 amd64 armhf arm64", "Codename": "bionic", "Components": "main", "Date": "Tue, 06 Apr 2021 21:05:41 UTC","Description": " Apt Repository for the Node.JS 10.x Branch", "Label": "Node Source", "Origin": "Node Source"}, "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "test", "Status": 0, "WorkerPID": 0, "FilterWithDeps": true, "SkipComponentCheck": true, "SkipArchitectureCheck": true, "DownloadSources": true, "DownloadUdebs": true, "DownloadInstaller": true}'
+                   )
+        self.assertEqual(
+            self.mapi.create(name="aptly-mirror", archiveurl='https://deb.nodesource.com/node_10.x/',
+                             distribution='bionic', components=["main"],
+                             architectures=["amd64"],
+                             filter="test", download_udebs=True,
+                             download_sources=True, download_installer=True,
+                             skip_component_check=True, filter_with_deps=True,
+                             keyrings="/path/to/keyring", ignore_signatures=True),
+            Mirror(
+                uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
+                name="aptly-mirror",
+                archiveurl="https://deb.nodesource.com/node_10.x/",
+                distribution='bionic',
+                components=["main"],
+                architectures=["amd64"],
+                downloaddate='0001-01-01T00:00:00Z',
+                meta={"Architectures": "i386 amd64 armhf arm64",
+                      "Codename": "bionic",
+                      "Components": "main",
+                      "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                      "Description": " Apt Repository for the Node.JS 10.x Branch",
+                      "Label": "Node Source", "Origin": "Node Source"},
+                filter="test",
+                status=0,
+                worker_pid=0,
+                filter_with_deps=True,
+                skip_component_check=True,
+                skip_architecture_check=True,
+                download_sources=True,
+                download_udebs=True,
+                download_installer=True
+
+            )
+        )
+
+    def test_list(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.get("http://test/api/mirrors",
+                  text='[{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb", "Name": "aptly-mirror", "ArchiveRoot": "https://deb.nodesource.com/node_10.x/", "Distribution": "bionic", "Components": ["main"], "Architectures": ["amd64"], "Meta": {"Architectures": "i386 amd64 armhf arm64", "Codename": "bionic", "Components": "main", "Date": "Tue, 06 Apr 2021 21:05:41 UTC","Description": " Apt Repository for the Node.JS 10.x Branch", "Label": "Node Source", "Origin": "Node Source"}, "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "", "Status": 0, "WorkerPID": 0, "FilterWithDeps": false, "SkipComponentCheck": false, "SkipArchitectureCheck": false, "DownloadSources": false, "DownloadUdebs": false, "DownloadInstaller": false}]'
+                  )
+        self.assertSequenceEqual(
+            self.mapi.list(),
+            [
+                Mirror(
+                    uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
+                    name="aptly-mirror",
+                    archiveurl="https://deb.nodesource.com/node_10.x/",
+                    distribution='bionic',
+                    components=["main"],
+                    architectures=["amd64"],
+                    downloaddate='0001-01-01T00:00:00Z',
+                    meta={"Architectures": "i386 amd64 armhf arm64",
+                          "Codename": "bionic",
+                          "Components": "main",
+                          "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                          "Description": " Apt Repository for the Node.JS 10.x Branch",
+                          "Label": "Node Source", "Origin": "Node Source"},
+                    filter="",
+                    status=0,
+                    worker_pid=0,
+                    filter_with_deps=False,
+                    skip_component_check=False,
+                    skip_architecture_check=False,
+                    download_sources=False,
+                    download_udebs=False,
+                    download_installer=False
+
+                )
+            ]
+        )
+
+    def test_show(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.get("http://test/api/mirrors/aptly-mirror",
+                  text='{"UUID": "2cb5985a-a23f-4a1f-8eb6-d5409193b4eb", "Name": "aptly-mirror", "ArchiveRoot": "https://deb.nodesource.com/node_10.x/", "Distribution": "bionic", "Components": ["main"], "Architectures": ["amd64"], "Meta": {"Architectures": "i386 amd64 armhf arm64", "Codename": "bionic", "Components": "main", "Date": "Tue, 06 Apr 2021 21:05:41 UTC","Description": " Apt Repository for the Node.JS 10.x Branch", "Label": "Node Source", "Origin": "Node Source"}, "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "", "Status": 0, "WorkerPID": 0, "FilterWithDeps": false, "SkipComponentCheck": false, "SkipArchitectureCheck": false, "DownloadSources": false, "DownloadUdebs": false, "DownloadInstaller": false}'
+                  )
+        self.assertEqual(
+            self.mapi.show(name="aptly-mirror"),
+            Mirror(
+                uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
+                name="aptly-mirror",
+                archiveurl="https://deb.nodesource.com/node_10.x/",
+                distribution='bionic',
+                components=["main"],
+                architectures=["amd64"],
+                downloaddate='0001-01-01T00:00:00Z',
+                meta={"Architectures": "i386 amd64 armhf arm64",
+                      "Codename": "bionic",
+                      "Components": "main",
+                      "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                      "Description": " Apt Repository for the Node.JS 10.x Branch",
+                      "Label": "Node Source", "Origin": "Node Source"},
+                filter="",
+                status=0,
+                worker_pid=0,
+                filter_with_deps=False,
+                skip_component_check=False,
+                skip_architecture_check=False,
+                download_sources=False,
+                download_udebs=False,
+                download_installer=False
+
+            )
+        )
+
+    def test_list_packages(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.get("http://test/api/mirrors/aptly-mirror/packages",
+                  text='["Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572"]')
+        self.assertSequenceEqual(
+            self.mapi.list_packages(
+                name="aptly-mirror", query=("nodejs"), with_deps=True),
+            [
+                Package(
+                    key="Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572",
+                    short_key=None,
+                    files_hash=None,
+                    fields=None,
+                )
+            ],
+        )
+
+    def test_list_packages_details(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.get(
+            "http://test/api/mirrors/aptly-mirror/packages?format=details",
+            text="""[{
+                      "Architecture":"amd64",
+                      "Conflicts": "nodejs-dev, nodejs-legacy, npm",
+                      "Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4), libstdc++6 (>= 4.4.0), python-minimal, ca-certificates",
+                      "Description":"Node.js event-based server-side javascript engine\\n",
+                      "Filename":"nodejs_10.24.1-1nodesource1_amd64.deb",
+                      "FilesHash":"1f74a6abf6acc572",
+                      "Homepage":"https://nodejs.org",
+                      "Installed-Size":"78630",
+                      "Key":"Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572",
+                      "License":"unknown",
+                      "MD5sum":"6d9f0e30396cb6c20945ff6de2f9f322",
+                      "Maintainer":"Ivan Iguaran <ivan@nodesource.com>",
+                      "Package":"nodejs",
+                      "Priority":"optional",
+                      "Provides":"nodejs-dev, nodejs-legacy, npm",
+                      "SHA1":"a3bc5a29614eab366bb3644abb1e602b5c8953d5",
+                      "SHA256":"4b374d16b536cf1a3963ddc4575ed2b68b28b0b5ea6eefe93c942dfc0ed35177",
+                      "SHA512":"bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f07969ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460",
+                      "Section":"web",
+                      "ShortKey":"Pamd64 nodejs 10.24.1-1nodesource1",
+                      "Size":"15949164",
+                      "Version":"10.24.1-1nodesource1"
+                 }]"""
+        )
+        self.assertEqual(
+            self.mapi.list_packages(
+                "aptly-mirror", detailed=True, with_deps=True, query="nodejs"),
+            [
+                Package(
+                    key='Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572',
+                    short_key='Pamd64 nodejs 10.24.1-1nodesource1',
+                    files_hash='1f74a6abf6acc572',
+                    fields={
+                        'Architecture': 'amd64',
+                        'Conflicts': 'nodejs-dev, nodejs-legacy, npm',
+                        'Depends': '1libc6 (>= 2.9), libgcc1 (>= 1:3.4), libstdc++6 (>= 4.4.0), python-minimal, ca-certificates',
+                        'Description': 'Node.js event-based server-side javascript engine\n',
+                        'Filename': 'nodejs_10.24.1-1nodesource1_amd64.deb',
+                        'FilesHash': '1f74a6abf6acc572',
+                        'Homepage': 'https://nodejs.org',
+                        'Installed-Size': '78630',
+                        'Key': 'Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572',
+                        'License': 'unknown',
+                        'MD5sum': '6d9f0e30396cb6c20945ff6de2f9f322',
+                        'Maintainer': 'Ivan Iguaran <ivan@nodesource.com>',
+                        'Package': 'nodejs',
+                        'Priority': 'optional',
+                        'Provides': 'nodejs-dev, nodejs-legacy, npm',
+                        'SHA1': 'a3bc5a29614eab366bb3644abb1e602b5c8953d5',
+                        'SHA256': '4b374d16b536cf1a3963ddc4575ed2b68b28b0b5ea6eefe93c942dfc0ed35177',
+                        'SHA512': 'bf203bb319de0c5f7ed3b6ba69de39b1ea8b5086b872561379bd462dd93f0796'
+                                  '9ca64fa01ade01ff08fa13a4e5e28625b59292ba44bc01ba876ec95875630460',
+                        'Section': 'web',
+                        'ShortKey': 'Pamd64 nodejs 10.24.1-1nodesource1',
+                        'Size': '15949164',
+                        'Version': '10.24.1-1nodesource1'
+                    }
+                )
+            ]
+        )
+
+    def test_delete(self, *, rmock: requests_mock.Mocker) -> None:
+        with self.assertRaises(requests_mock.NoMockAddress):
+            self.mapi.delete(name="aptly-mirror")
+
+    def test_update(self, *, rmock: requests_mock.Mocker) -> None:
+        with self.assertRaises(requests_mock.NoMockAddress):
+            self.mapi.update(name="aptly-mirror", ignore_signatures=True)
+
+    def test_edit(self, *, rmock: requests_mock.Mocker) -> None:
+        with self.assertRaises(requests_mock.NoMockAddress):
+            self.mapi.edit(name="aptly-mirror", newname="aptly-mirror-renamed",
+                           archiveurl='https://deb.nodesource.com/node_10.x/',
+                           architectures=["i386", "amd64"], filter="test",
+                           components=["main"], keyrings="/path/to/keyring",
+                           skip_existing_packages=True, ignore_checksums=True,
+                           download_udebs=True, download_sources=True,
+                           skip_component_check=True, filter_with_deps=True,
+                           ignore_signatures=True, force_update=True),
+
+    def test_delete_validation(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.delete("http://test/api/mirrors/aptly-mirror")
+        self.mapi.delete(name="aptly-mirror")
+
+    def test_update_validation(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.put("http://test/api/mirrors/aptly-mirror")
+        self.mapi.update(name="aptly-mirror")
+
+    def test_edit_validation(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.put("http://test/api/mirrors/aptly-mirror",
+                  text='{"Name":"aptly-mirror-bla", "IgnoreSignatures": true}')
+        self.mapi.edit(name="aptly-mirror", newname="aptly-mirror-renamed")

--- a/aptly_api/tests/test_mirrors.py
+++ b/aptly_api/tests/test_mirrors.py
@@ -192,7 +192,7 @@ class MirrorsAPISectionTests(TestCase):
                  '"Filename":"nodejs_10.24.1-1nodesource1_amd64.deb",'
                  '"FilesHash":"1f74a6abf6acc572",'
                  '"Homepage":"https://nodejs.org",'
-                 '"Installed-Size":"78630", "Key":"Pamd64 nodejs 10.24.1-1nodesource11f74a6abf6acc572",'
+                 '"Installed-Size":"78630", "Key":"Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572",'
                  '"License":"unknown",'
                  '"MD5sum":"6d9f0e30396cb6c20945ff6de2f9f322","Maintainer":"Ivan Iguaran <ivan@nodesource.com>",'
                  '"Package":"nodejs",'

--- a/aptly_api/tests/test_mirrors.py
+++ b/aptly_api/tests/test_mirrors.py
@@ -16,7 +16,7 @@ from aptly_api.parts.mirrors import MirrorsAPISection, Mirror
 class MirrorsAPISectionTests(TestCase):
     def __init__(self, *args: Any) -> None:
         super().__init__(*args)
-        self.mapi = MirrorsAPISection("http://test/")
+        self.miapi = MirrorsAPISection("http://test/")
 
     def test_create(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.post("http://test/api/mirrors",
@@ -25,25 +25,25 @@ class MirrorsAPISectionTests(TestCase):
                    "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
                    "Distribution": "bionic", "Components": ["main"],
                    "Architectures": ["amd64"],
-                   "Meta": {"Architectures": "i386 amd64 armhf arm64",
+                   "Meta": [{"Architectures": "i386 amd64 armhf arm64",
                    "Codename": "bionic", "Components": "main",
                    "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
                    "Description": " Apt Repository for the Node.JS 10.x Branch",
-                   "Label": "Node Source", "Origin": "Node Source"},
+                   "Label": "Node Source", "Origin": "Node Source"}],
                    "LastDownloadDate": "0001-01-01T00:00:00Z",
                    "Filter": "test", "Status": 0, "WorkerPID": 0,
                    "FilterWithDeps": true, "SkipComponentCheck": true,
                    "SkipArchitectureCheck": true, "DownloadSources": true,
                    "DownloadUdebs": true, "DownloadInstaller": true}"""
                    )
-        self.assertEqual(
-            self.mapi.create(name="aptly-mirror", archiveurl='https://deb.nodesource.com/node_10.x/',
-                             distribution='bionic', components=["main"],
-                             architectures=["amd64"],
-                             filter="test", download_udebs=True,
-                             download_sources=True, download_installer=True,
-                             skip_component_check=True, filter_with_deps=True,
-                             keyrings="/path/to/keyring", ignore_signatures=True),
+        self.assertSequenceEqual(
+            self.miapi.create(name="aptly-mirror", archiveurl='https://deb.nodesource.com/node_10.x/',
+                              distribution='bionic', components=["main"],
+                              architectures=["amd64"],
+                              filter="test", download_udebs=True,
+                              download_sources=True, download_installer=True,
+                              skip_component_check=True, filter_with_deps=True,
+                              keyrings=["/path/to/keyring"], ignore_signatures=True),
             Mirror(
                 uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
                 name="aptly-mirror",
@@ -52,12 +52,12 @@ class MirrorsAPISectionTests(TestCase):
                 components=["main"],
                 architectures=["amd64"],
                 downloaddate='0001-01-01T00:00:00Z',
-                meta={"Architectures": "i386 amd64 armhf arm64",
+                meta=[{"Architectures": "i386 amd64 armhf arm64",
                       "Codename": "bionic",
-                      "Components": "main",
-                      "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
-                      "Description": " Apt Repository for the Node.JS 10.x Branch",
-                      "Label": "Node Source", "Origin": "Node Source"},
+                       "Components": "main",
+                       "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                       "Description": " Apt Repository for the Node.JS 10.x Branch",
+                       "Label": "Node Source", "Origin": "Node Source"}],
                 filter="test",
                 status=0,
                 worker_pid=0,
@@ -78,11 +78,11 @@ class MirrorsAPISectionTests(TestCase):
                   "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
                   "Distribution": "bionic", "Components": ["main"],
                   "Architectures": ["amd64"],
-                  "Meta": {"Architectures": "i386 amd64 armhf arm64",
+                  "Meta": [{"Architectures": "i386 amd64 armhf arm64",
                   "Codename": "bionic", "Components": "main",
                   "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
                   "Description": " Apt Repository for the Node.JS 10.x Branch",
-                  "Label": "Node Source", "Origin": "Node Source"},
+                  "Label": "Node Source", "Origin": "Node Source"}],
                   "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
                   "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
                   "SkipComponentCheck": false, "SkipArchitectureCheck": false,
@@ -90,7 +90,7 @@ class MirrorsAPISectionTests(TestCase):
                   "DownloadInstaller": false}]"""
                   )
         self.assertSequenceEqual(
-            self.mapi.list(),
+            self.miapi.list(),
             [
                 Mirror(
                     uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
@@ -100,12 +100,12 @@ class MirrorsAPISectionTests(TestCase):
                     components=["main"],
                     architectures=["amd64"],
                     downloaddate='0001-01-01T00:00:00Z',
-                    meta={"Architectures": "i386 amd64 armhf arm64",
+                    meta=[{"Architectures": "i386 amd64 armhf arm64",
                           "Codename": "bionic",
-                          "Components": "main",
-                          "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
-                          "Description": " Apt Repository for the Node.JS 10.x Branch",
-                          "Label": "Node Source", "Origin": "Node Source"},
+                           "Components": "main",
+                           "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                           "Description": " Apt Repository for the Node.JS 10.x Branch",
+                           "Label": "Node Source", "Origin": "Node Source"}],
                     filter="",
                     status=0,
                     worker_pid=0,
@@ -127,19 +127,19 @@ class MirrorsAPISectionTests(TestCase):
                   "ArchiveRoot": "https://deb.nodesource.com/node_10.x/",
                   "Distribution": "bionic", "Components": ["main"],
                   "Architectures": ["amd64"],
-                  "Meta": {"Architectures": "i386 amd64 armhf arm64",
+                  "Meta": [{"Architectures": "i386 amd64 armhf arm64",
                   "Codename": "bionic", "Components": "main",
                   "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
                   "Description": " Apt Repository for the Node.JS 10.x Branch",
-                  "Label": "Node Source", "Origin": "Node Source"},
+                  "Label": "Node Source", "Origin": "Node Source"}],
                   "LastDownloadDate": "0001-01-01T00:00:00Z", "Filter": "",
                   "Status": 0, "WorkerPID": 0, "FilterWithDeps": false,
                   "SkipComponentCheck": false, "SkipArchitectureCheck": false,
                   "DownloadSources": false, "DownloadUdebs": false,
                   "DownloadInstaller": false}"""
                   )
-        self.assertEqual(
-            self.mapi.show(name="aptly-mirror"),
+        self.assertSequenceEqual(
+            self.miapi.show(name="aptly-mirror"),
             Mirror(
                 uuid='2cb5985a-a23f-4a1f-8eb6-d5409193b4eb',
                 name="aptly-mirror",
@@ -148,12 +148,12 @@ class MirrorsAPISectionTests(TestCase):
                 components=["main"],
                 architectures=["amd64"],
                 downloaddate='0001-01-01T00:00:00Z',
-                meta={"Architectures": "i386 amd64 armhf arm64",
+                meta=[{"Architectures": "i386 amd64 armhf arm64",
                       "Codename": "bionic",
-                      "Components": "main",
-                      "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
-                      "Description": " Apt Repository for the Node.JS 10.x Branch",
-                      "Label": "Node Source", "Origin": "Node Source"},
+                       "Components": "main",
+                       "Date": "Tue, 06 Apr 2021 21:05:41 UTC",
+                       "Description": " Apt Repository for the Node.JS 10.x Branch",
+                       "Label": "Node Source", "Origin": "Node Source"}],
                 filter="",
                 status=0,
                 worker_pid=0,
@@ -171,7 +171,7 @@ class MirrorsAPISectionTests(TestCase):
         rmock.get("http://test/api/mirrors/aptly-mirror/packages",
                   text='["Pamd64 nodejs 10.24.1-1nodesource1 1f74a6abf6acc572"]')
         self.assertSequenceEqual(
-            self.mapi.list_packages(
+            self.miapi.list_packages(
                 name="aptly-mirror", query=("nodejs"), with_deps=True),
             [
                 Package(
@@ -213,8 +213,8 @@ class MirrorsAPISectionTests(TestCase):
                       "Version":"10.24.1-1nodesource1"
                  }]"""
         )
-        self.assertEqual(
-            self.mapi.list_packages(
+        self.assertSequenceEqual(
+            self.miapi.list_packages(
                 "aptly-mirror", detailed=True, with_deps=True, query="nodejs"),
             [
                 Package(
@@ -253,32 +253,32 @@ class MirrorsAPISectionTests(TestCase):
 
     def test_delete(self, *, rmock: requests_mock.Mocker) -> None:
         with self.assertRaises(requests_mock.NoMockAddress):
-            self.mapi.delete(name="aptly-mirror")
+            self.miapi.delete(name="aptly-mirror")
 
     def test_update(self, *, rmock: requests_mock.Mocker) -> None:
         with self.assertRaises(requests_mock.NoMockAddress):
-            self.mapi.update(name="aptly-mirror", ignore_signatures=True)
+            self.miapi.update(name="aptly-mirror", ignore_signatures=True)
 
     def test_edit(self, *, rmock: requests_mock.Mocker) -> None:
         with self.assertRaises(requests_mock.NoMockAddress):
-            self.mapi.edit(name="aptly-mirror", newname="aptly-mirror-renamed",
-                           archiveurl='https://deb.nodesource.com/node_10.x/',
-                           architectures=["i386", "amd64"], filter="test",
-                           components=["main"], keyrings="/path/to/keyring",
-                           skip_existing_packages=True, ignore_checksums=True,
-                           download_udebs=True, download_sources=True,
-                           skip_component_check=True, filter_with_deps=True,
-                           ignore_signatures=True, force_update=True),
+            self.miapi.edit(name="aptly-mirror", newname="aptly-mirror-renamed",
+                            archiveurl='https://deb.nodesource.com/node_10.x/',
+                            architectures=["i386", "amd64"], filter="test",
+                            components=["main"], keyrings=["/path/to/keyring"],
+                            skip_existing_packages=True, ignore_checksums=True,
+                            download_udebs=True, download_sources=True,
+                            skip_component_check=True, filter_with_deps=True,
+                            ignore_signatures=True, force_update=True)
 
     def test_delete_validation(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.delete("http://test/api/mirrors/aptly-mirror")
-        self.mapi.delete(name="aptly-mirror")
+        self.miapi.delete(name="aptly-mirror")
 
     def test_update_validation(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/mirrors/aptly-mirror")
-        self.mapi.update(name="aptly-mirror")
+        self.miapi.update(name="aptly-mirror")
 
     def test_edit_validation(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.put("http://test/api/mirrors/aptly-mirror",
                   text='{"Name":"aptly-mirror-bla", "IgnoreSignatures": true}')
-        self.mapi.edit(name="aptly-mirror", newname="aptly-mirror-renamed")
+        self.miapi.edit(name="aptly-mirror", newname="aptly-mirror-renamed")

--- a/aptly_api/tests/test_mirrors.py
+++ b/aptly_api/tests/test_mirrors.py
@@ -185,8 +185,8 @@ class MirrorsAPISectionTests(TestCase):
         rmock.get(
             "http://test/api/mirrors/aptly-mirror/packages?format=details",
             text='[{"Architecture":"amd64",'
-                 '"Conflicts": "nodejs-dev, nodejs-legacy, npm",'
-                 '"Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4),'
+                 '"Conflicts":"nodejs-dev, nodejs-legacy, npm",'
+                 '"Depends":"1libc6 (>= 2.9), libgcc1 (>= 1:3.4), '
                  'libstdc++6 (>= 4.4.0), python-minimal, ca-certificates",'
                  '"Description":" Node.js event-based server-side javascript engine\\n",'
                  '"Filename":"nodejs_10.24.1-1nodesource1_amd64.deb",'
@@ -205,7 +205,7 @@ class MirrorsAPISectionTests(TestCase):
                  '"Section":"web",'
                  '"ShortKey":"Pamd64 nodejs 10.24.1-1nodesource1",'
                  '"Size":"15949164",'
-                 'Version":"10.24.1-1nodesource1"}]')
+                 '"Version":"10.24.1-1nodesource1"}]')
         self.assertSequenceEqual(
             self.miapi.list_packages(
                 "aptly-mirror", detailed=True, with_deps=True, query="nodejs"),

--- a/aptly_api/tests/test_snapshots.py
+++ b/aptly_api/tests/test_snapshots.py
@@ -34,13 +34,15 @@ class SnapshotAPISectionTests(TestCase):
                     name='stretch-security-1',
                     description='Snapshot from mirror [stretch-security]: http://security.debian.org/debian-security/ '
                                 'stretch/updates',
-                    created_at=iso8601.parse_date('2017-06-03T21:36:22.2692213Z')
+                    created_at=iso8601.parse_date(
+                        '2017-06-03T21:36:22.2692213Z')
                 ),
                 Snapshot(
                     name='stretch-updates-1',
                     description='Snapshot from mirror [stretch-updates]: http://ftp-stud.hs-esslingen.de/debian/ '
                                 'stretch-updates',
-                    created_at=iso8601.parse_date('2017-06-03T21:36:22.431767659Z')
+                    created_at=iso8601.parse_date(
+                        '2017-06-03T21:36:22.431767659Z')
                 )
             ]
         )
@@ -136,8 +138,10 @@ class SnapshotAPISectionTests(TestCase):
         self.assertIsNotNone(expected.fields)
 
         self.assertDictEqual(
-            parsed.fields if parsed.fields else {},  # make sure that mypy doesn't error on this being potentially None
-            expected.fields if expected.fields else {},  # this can't happen unless Package.__init__ is fubared
+            # make sure that mypy doesn't error on this being potentially None
+            parsed.fields if parsed.fields else {},
+            # this can't happen unless Package.__init__ is fubared
+            expected.fields if expected.fields else {},
         )
 
     def test_show(self, *, rmock: requests_mock.Mocker) -> None:
@@ -159,7 +163,8 @@ class SnapshotAPISectionTests(TestCase):
                   text='{"Name":"aptly-repo-2","CreatedAt":"2017-06-03T23:43:40.275605639Z",'
                        '"Description":"test"}')
         self.assertEqual(
-            self.sapi.update("aptly-repo-1", newname="aptly-repo-2", newdescription="test"),
+            self.sapi.update(
+                "aptly-repo-1", newname="aptly-repo-2", newdescription="test"),
             Snapshot(
                 name='aptly-repo-2',
                 description='test',
@@ -198,5 +203,19 @@ class SnapshotAPISectionTests(TestCase):
                 name='aptly-repo-2',
                 description='test',
                 created_at=iso8601.parse_date('2017-06-07T14:19:07.706408213Z')
+            )
+        )
+
+    def test_create_from_mirror(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.post("http://test/api/mirrors/aptly-mirror/snapshots",
+                   text='{"Name":"aptly-mirror-snap","CreatedAt":"2022-11-29T21:43:45.275605639Z",'
+                        '"Description":"Snapshot from local mirror [aptly-mirror]"}')
+        self.assertEqual(
+            self.sapi.create_from_mirror(mirrorname="aptly-mirror", snapshotname="aptly-mirror-snap",
+                                         description='Snapshot from local repo [aptly-repo]'),
+            Snapshot(
+                name='aptly-mirror-snap',
+                description='Snapshot from local mirror [aptly-mirror]',
+                created_at=iso8601.parse_date('2022-11-29T21:43:45.275605639Z')
             )
         )

--- a/aptly_api/tests/test_snapshots.py
+++ b/aptly_api/tests/test_snapshots.py
@@ -207,6 +207,7 @@ class SnapshotAPISectionTests(TestCase):
         )
 
     def test_create_from_mirror(self, *, rmock: requests_mock.Mocker) -> None:
+        expected = {'Name': 'aptly-mirror-snap', 'Description': 'Snapshot from local repo [aptly-repo]'}
         rmock.post("http://test/api/mirrors/aptly-mirror/snapshots",
                    text='{"Name":"aptly-mirror-snap","CreatedAt":"2022-11-29T21:43:45.275605639Z",'
                         '"Description":"Snapshot from local mirror [aptly-mirror]"}')
@@ -219,3 +220,4 @@ class SnapshotAPISectionTests(TestCase):
                 created_at=iso8601.parse_date('2022-11-29T21:43:45.275605639Z')
             )
         )
+        self.assertEqual(rmock.request_history[0].json(), expected)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 requests-mock==1.12.1
 coverage==7.6.12
 coveralls==4.0.1
-flake8==7.1.2
+flake8==7.3.0
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.19.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 requests-mock==1.12.1
-coverage==7.6.3
+coverage==7.6.7
 coveralls==4.0.1
 flake8==7.1.1
 pep257==0.7.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ flake8==7.1.1
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.18.0
-mypy==1.12.0
+mypy==1.13.0
 pytest==8.3.3
 pytest-cov==6.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,5 @@ pep257==0.7.0
 doc8==1.1.2
 Pygments==2.19.2
 mypy==1.15.0
-pytest==8.3.3
+pytest==8.4.1
 pytest-cov==6.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 requests-mock==1.12.1
-coverage==7.6.1
+coverage==7.6.3
 coveralls==4.0.1
 flake8==7.1.1
 pep257==0.7.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,4 @@ doc8==1.1.2
 Pygments==2.18.0
 mypy==1.12.0
 pytest==8.3.3
-pytest-cov==5.0.0
+pytest-cov==6.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ flake8==7.1.1
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.18.0
-mypy==1.11.1
+mypy==1.11.2
 pytest==8.3.3
 pytest-cov==5.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ coverage==7.6.1
 coveralls==4.0.1
 flake8==7.1.1
 pep257==0.7.0
-doc8==1.1.1
+doc8==1.1.2
 Pygments==2.18.0
 mypy==1.11.1
 pytest==8.3.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 requests-mock==1.12.1
-coverage==7.6.7
+coverage==7.6.12
 coveralls==4.0.1
 flake8==7.1.2
 pep257==0.7.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 requests-mock==1.12.1
-coverage==7.6.12
+coverage==7.10.1
 coveralls==4.0.1
 flake8==7.3.0
 pep257==0.7.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ coveralls==4.0.1
 flake8==7.1.2
 pep257==0.7.0
 doc8==1.1.2
-Pygments==2.18.0
+Pygments==2.19.2
 mypy==1.15.0
 pytest==8.3.3
 pytest-cov==6.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,4 @@ doc8==1.1.2
 Pygments==2.19.2
 mypy==1.15.0
 pytest==8.4.1
-pytest-cov==6.0.0
+pytest-cov==6.2.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ flake8==7.3.0
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.19.2
-mypy==1.15.0
+mypy==1.17.0
 pytest==8.4.1
 pytest-cov==6.2.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ flake8==7.1.1
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.18.0
-mypy==1.11.2
+mypy==1.12.0
 pytest==8.3.3
 pytest-cov==5.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ flake8==7.1.2
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.18.0
-mypy==1.13.0
+mypy==1.15.0
 pytest==8.3.3
 pytest-cov==6.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 requests-mock==1.12.1
 coverage==7.6.7
 coveralls==4.0.1
-flake8==7.1.1
+flake8==7.1.2
 pep257==0.7.0
 doc8==1.1.2
 Pygments==2.18.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,5 @@ pep257==0.7.0
 doc8==1.1.1
 Pygments==2.18.0
 mypy==1.11.1
-pytest==8.3.2
+pytest==8.3.3
 pytest-cov==5.0.0


### PR DESCRIPTION
> The requests library has support for passing additional information, such as the intended filename on upload, the content-type and additional headers, by passing a tuple with 2, 3 or 4 elements instead of just a file object.
> 
> See "POST a Multipart-Encoded File" in the requests documentation for more details:
> https://requests.readthedocs.io/en/latest/user/quickstart/#post-a-multipart-encoded-file
> 
> Extend aptly_api files API to also be able to take similar tuples when uploading files to Aptly.
> 
> One useful use case is to pass a proper package filename, in cases where packages are generated simply as <name>.deb by upstream projects (usually via non native Debian build systems) but should more properly be stored as <name>_<epoch>:<version>_<arch>.deb. Renaming files locally is a possibility, but potentially runs into permission issues. Being able to specify the filename to the API solves this in a more elegant way, without having to modify the local filesystem. The package information can be easily derived using debian.debfile.DebFile() to inspect a package file, in specific gencontrol() returns the fields of the control file which can be used to derive the expected filename.
> 
> Tested locally by uploading files to aptly using the modified API. Also added a test (even though it mostly relies on mocks.) Confirmed mypy is happy with all the type annotation.


From [#129] by @filbranden. Copied the PR here to rebase and run tests.