### PR TITLE
Add support for filename, content-type and headers when uploading files

### DIFF
--- a/aptly_api/parts/files.py
+++ b/aptly_api/parts/files.py
@@ -25,6 +25,12 @@ class FilesAPISection(BaseAPIClient):
         return cast(List[str], resp.json())
 
     def upload(self, destination: str, *files: Union[str, _tuplefiletype]) -> Sequence[str]:
+        """Upload files to an Aptly upload directory.
+
+        ``files`` accepts either local file paths or requests-style multipart
+        tuples: ``(filename, file)``, ``(filename, file, content_type)`` or
+        ``(filename, file, content_type, headers)``.
+        """
         to_upload = []  # type: List[Tuple[str, Union[BinaryIO, _tuplefiletype]]]
         for f in files:
             if isinstance(f, tuple):

--- a/aptly_api/tests/test_files.py
+++ b/aptly_api/tests/test_files.py
@@ -45,6 +45,14 @@ class FilesAPISectionTests(TestCase):
         with self.assertRaises(AptlyAPIException):
             self.fapi.upload("test", os.path.join(os.path.dirname(__file__), "testpkg.deb"))
 
+    def test_upload_with_tuples(self, *, rmock: requests_mock.Mocker) -> None:
+        rmock.post("http://test/api/files/test", text='["test/otherpkg.deb", "test/binpkg.deb"]')
+        with open(os.path.join(os.path.dirname(__file__), "testpkg.deb"), "rb") as pkgf:
+            self.assertSequenceEqual(
+                self.fapi.upload("test", ("otherpkg.deb", pkgf), ("binpkg.deb", b"dpkg-contents")),
+                ['test/otherpkg.deb', 'test/binpkg.deb'],
+            )
+
     def test_delete(self, *, rmock: requests_mock.Mocker) -> None:
         rmock.delete("http://test/api/files/test",
                      text='{}')


### PR DESCRIPTION
> The requests library has support for passing additional information, such as the intended filename on upload, the content-type and additional headers, by passing a tuple with 2, 3 or 4 elements instead of just a file object.
> 
> See "POST a Multipart-Encoded File" in the requests documentation for more details:
> https://requests.readthedocs.io/en/latest/user/quickstart/#post-a-multipart-encoded-file
> 
> Extend aptly_api files API to also be able to take similar tuples when uploading files to Aptly.
> 
> One useful use case is to pass a proper package filename, in cases where packages are generated simply as `<name>.deb` by upstream projects (usually via non native Debian build systems) but should more properly be stored as `<name>_<epoch>:<version>_<arch>.deb`. Renaming files locally is a possibility, but potentially runs into permission issues. Being able to specify the filename to the API solves this in a more elegant way, without having to modify the local filesystem. The package information can be easily derived using `debian.debfile.DebFile()` to inspect a package file, in specific `gencontrol()` returns the fields of the control file which can be used to derive the expected filename.
> 
> Tested locally by uploading files to aptly using the modified API. Also added a test (even though it mostly relies on mocks.) Confirmed mypy is happy with all the type annotation.
> 

Copied from #129 by @filbranden